### PR TITLE
Remove unused imports

### DIFF
--- a/jwtek/core/extractor.py
+++ b/jwtek/core/extractor.py
@@ -1,5 +1,4 @@
 import re
-import requests
 
 JWT_REGEX = r"eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+"
 

--- a/jwtek/core/forge.py
+++ b/jwtek/core/forge.py
@@ -1,7 +1,6 @@
 import base64
 import json
 import jwt
-from jwt import algorithms
 
 def forge_jwt(alg, payload_str, secret=None, privkey_path=None):
     try:

--- a/jwtek/core/static_analysis.py
+++ b/jwtek/core/static_analysis.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 import time
 
 def run_all_checks(header, payload):


### PR DESCRIPTION
## Summary
- tidy extractor, forge, and static_analysis imports
- run compile step and attempt flake8

## Testing
- `flake8 jwtek/core/extractor.py jwtek/core/forge.py jwtek/core/static_analysis.py` *(fails: command not found)*
- `python -m compileall jwtek/core/extractor.py jwtek/core/forge.py jwtek/core/static_analysis.py`

------
https://chatgpt.com/codex/tasks/task_b_686d04060ee883278a0432e634eebb0d