### PR TITLE
Add colored UI helpers with disable flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ different ways:
 - Forge custom tokens using `none`, `HS256`, or `RS256`
 - Guided exploitation advice with PoCs and bypass testing
 - Extendable and modular structure
+- Colored console output for readability (disable with `--no-color` or `JWTEK_NO_COLOR=1`)
 
 ---
 
@@ -69,6 +70,7 @@ different ways:
 ```bash
 python3 jwtek.py <command> [options]
 ```
+Use `--no-color` or set `JWTEK_NO_COLOR=1` to disable ANSI colours.
 
 ### 🔍 Analyze a JWT
 

--- a/jwtek/__main__.py
+++ b/jwtek/__main__.py
@@ -77,6 +77,7 @@ def main(argv=None):
         prog='jwtek',
         description="🛡️ JWTEK: JWT Security Analysis & Exploitation Tool"
     )
+    parser_cli.add_argument('--no-color', action='store_true', help='Disable colored output')
 
     subparsers = parser_cli.add_subparsers(dest='command', help='Available commands')
 
@@ -117,6 +118,8 @@ def main(argv=None):
 
 
     args = parser_cli.parse_args()
+    if getattr(args, 'no_color', False):
+        ui.set_no_color(True)
     token = None
 
     if args.command == 'analyze':

--- a/jwtek/core/audit.py
+++ b/jwtek/core/audit.py
@@ -1,5 +1,8 @@
+from . import ui
+
+
 def audit_claims(payload, custom_rules=None):
-    print("\n[🔍] Running claim audit...")
+    ui.info("\n[🔍] Running claim audit...")
 
     suspicious_keys = {
         "admin": (lambda v: v in [True, "true", 1, "1", "yes"], "high"),
@@ -20,10 +23,10 @@ def audit_claims(payload, custom_rules=None):
         check = data[0] if isinstance(data, tuple) else data
         severity = data[1] if isinstance(data, tuple) else "info"
         if key in payload and check(payload[key]):
-            print(f"[!] Suspicious claim: `{key}` = {payload[key]} (severity: {severity})")
+            ui.warn(f"Suspicious claim: `{key}` = {payload[key]} (severity: {severity})")
             flagged = True
 
     if not flagged:
-        print("[+] No suspicious claims found.")
+        ui.success("No suspicious claims found.")
     else:
-        print("[!] Review the above claims for potential privilege escalation.")
+        ui.warn("Review the above claims for potential privilege escalation.")

--- a/jwtek/core/exploits.py
+++ b/jwtek/core/exploits.py
@@ -2,7 +2,7 @@ import jwt
 import base64
 import json
 import requests
-from termcolor import cprint
+from . import ui
 
 
 def fetch_first_jwks_key(jwks_url):
@@ -19,7 +19,7 @@ def fetch_first_jwks_key(jwks_url):
 # === EXPLAIN FUNCTIONS ===
 
 def explain_alg_none():
-    print("\n[!] Exploit: 'alg: none'")
+    ui.warn("\n[!] Exploit: 'alg: none'")
     print("""
 ➤ Description:
   The JWT uses 'alg: none', meaning the signature is not verified.
@@ -40,7 +40,7 @@ def explain_alg_none():
 
 
 def explain_hs256_key_found(secret):
-    print(f"\n[!] Exploit: HS256 with guessable secret")
+    ui.warn(f"\n[!] Exploit: HS256 with guessable secret")
     print(f"""
 ➤ Description:
   The JWT is signed with a weak or guessable shared secret. You found it: **{secret}**
@@ -57,7 +57,7 @@ def explain_hs256_key_found(secret):
 
 
 def explain_rs256_downgrade():
-    print("\n[!] Exploit: RS256 to HS256 Downgrade (Key Confusion)")
+    ui.warn("\n[!] Exploit: RS256 to HS256 Downgrade (Key Confusion)")
     print("""
 ➤ Description:
   The application uses RS256 (public/private key signing) but doesn't enforce key type.
@@ -88,17 +88,17 @@ def explain_exploit(vuln_id, **kwargs):
     elif vuln_id == "hs256-key-found":
         secret = kwargs.get("secret")
         if not secret:
-            print("[!] Missing --secret argument.")
+            ui.error("[!] Missing --secret argument.")
         else:
             explain_hs256_key_found(secret)
     elif vuln_id == "alg-swap-rs256":
         explain_rs256_downgrade()
     else:
-        print(f"[~] No exploit guidance available for: {vuln_id}")
+        ui.info(f"[~] No exploit guidance available for: {vuln_id}")
 
 
 def list_available_exploits():
-    print("\n[+] Available exploit IDs:\n")
+    ui.info("\n[+] Available exploit IDs:\n")
     print("  - alg-none           → No signature verification")
     print("  - hs256-key-found    → HMAC key discovered via brute-force")
     print("  - alg-swap-rs256     → RS256 to HS256 downgrade attack")
@@ -121,34 +121,34 @@ def generate_poc_token(vuln_id, secret=None, jwks_url=None):
         if key:
             token = jwt.encode(payload, key, algorithm="HS256")
         else:
-            cprint("[!] Failed to fetch JWKS key", "red")
+            ui.error("[!] Failed to fetch JWKS key")
             return
     else:
-        cprint("[!] Cannot generate PoC: missing secret or invalid vuln ID.", "red")
+        ui.error("[!] Cannot generate PoC: missing secret or invalid vuln ID.")
         return
 
-    cprint(f"\n[+] PoC Token:", "green")
+    ui.success(f"\n[+] PoC Token:")
     print(token)
-    cprint("\n[+] Example Usage:", "yellow")
+    ui.info("\n[+] Example Usage:")
     print(f'curl -H "Authorization: Bearer {token}" https://target.com/api')
 
 
 # === AUTH BYPASS ===
 
 def attempt_bypass(vuln_id, token, url, jwks_url=None):
-    cprint(f"\n[🔍] Testing token bypass at: {url}", "cyan")
+    ui.info(f"\n[🔍] Testing token bypass at: {url}")
     if jwks_url and vuln_id == "alg-swap-rs256":
         key = fetch_first_jwks_key(jwks_url)
         if key:
             try:
                 token = jwt.encode({"user": "admin"}, key, algorithm="HS256")
-                cprint("[+] Crafted token using JWKS key", "green")
+                ui.success("[+] Crafted token using JWKS key")
             except Exception:
-                cprint("[!] Failed to craft token from JWKS", "red")
+                ui.error("[!] Failed to craft token from JWKS")
     headers = {"Authorization": f"Bearer {token}"}
     try:
         response = requests.get(url, headers=headers, timeout=5)
-        cprint(f"[+] Status Code: {response.status_code}", "green")
+        ui.success(f"[+] Status Code: {response.status_code}")
         print(response.text[:300] + "..." if len(response.text) > 300 else response.text)
     except Exception as e:
-        cprint(f"[!] Error during request: {e}", "red")
+        ui.error(f"[!] Error during request: {e}")

--- a/jwtek/core/forge.py
+++ b/jwtek/core/forge.py
@@ -1,12 +1,13 @@
 import base64
 import json
 import jwt
+from . import ui
 
 def forge_jwt(alg, payload_str, secret=None, privkey_path=None, kid=None):
     try:
         payload = json.loads(payload_str)
     except json.JSONDecodeError:
-        print("[!] Invalid payload format. Must be valid JSON.")
+        ui.error("Invalid payload format. Must be valid JSON.")
         return
 
     header = {"alg": alg, "typ": "JWT"}
@@ -17,33 +18,33 @@ def forge_jwt(alg, payload_str, secret=None, privkey_path=None, kid=None):
         header_b64 = base64.urlsafe_b64encode(json.dumps(header).encode()).decode().rstrip("=")
         payload_b64 = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode().rstrip("=")
         forged_token = f"{header_b64}.{payload_b64}."
-        print("\n[+] Forged JWT (alg=none):")
+        ui.success("\n[+] Forged JWT (alg=none):")
         print(forged_token)
         return
 
     elif alg == "HS256":
         if not secret:
-            print("[!] HS256 requires --secret to sign the token.")
+            ui.error("HS256 requires --secret to sign the token.")
             return
         token = jwt.encode(payload, secret, algorithm="HS256", headers=header)
-        print("\n[+] Forged JWT (HS256):")
+        ui.success("\n[+] Forged JWT (HS256):")
         print(token)
         return
 
     elif alg in {"RS256", "ES256", "PS256"}:
         if not privkey_path:
-            print("[!] {} requires --privkey path to sign the token.".format(alg))
+            ui.error("{} requires --privkey path to sign the token.".format(alg))
             return
         try:
             with open(privkey_path, "r") as f:
                 private_key = f.read()
         except Exception as e:
-            print(f"[!] Failed to read private key: {e}")
+            ui.error(f"Failed to read private key: {e}")
             return
         token = jwt.encode(payload, private_key, algorithm=alg, headers=header)
-        print(f"\n[+] Forged JWT ({alg}):")
+        ui.success(f"\n[+] Forged JWT ({alg}):")
         print(token)
         return
 
     else:
-        print(f"[!] Unsupported algorithm: {alg}")
+        ui.error(f"Unsupported algorithm: {alg}")

--- a/jwtek/core/parser.py
+++ b/jwtek/core/parser.py
@@ -1,5 +1,6 @@
 import base64
 import json
+from . import ui
 
 def _b64_decode(data):
     padding = '=' * (-len(data) % 4)
@@ -12,7 +13,7 @@ def decode_jwt(token):
         payload = json.loads(_b64_decode(payload_b64))
         return header, payload, signature_b64
     except Exception as e:
-        print(f"[!] Failed to decode JWT: {e}")
+        ui.error(f"Failed to decode JWT: {e}")
         return {}, {}, ''
 
 def pretty_print_jwt(header, payload, signature_b64):

--- a/jwtek/core/static_analysis.py
+++ b/jwtek/core/static_analysis.py
@@ -1,7 +1,8 @@
 import time
+from . import ui
 
 def run_all_checks(header, payload):
-    print("\n[+] Running static analysis...\n")
+    ui.info("\n[+] Running static analysis...\n")
 
     check_alg_none(header)
     check_weak_alg(header)
@@ -15,32 +16,32 @@ def run_all_checks(header, payload):
 def check_alg_none(header):
     alg = header.get("alg", "")
     if alg.lower() == "none":
-        print("[!] Vulnerable: alg=none detected (token may be accepted without a signature!)")
+        ui.error("Vulnerable: alg=none detected (token may be accepted without a signature!)")
     else:
-        print("[+] alg field OK:", alg)
+        ui.success(f"alg field OK: {alg}")
 
 def check_weak_alg(header):
     weak = {"HS256", "HS384", "HS512"}
     if header.get("alg") in weak:
-        print(f"[!] Warning: Weak symmetric algorithm used ({header['alg']}). Brute-force may be possible.")
+        ui.warn(f"Warning: Weak symmetric algorithm used ({header['alg']}). Brute-force may be possible.")
     else:
-        print(f"[+] Algorithm used is: {header.get('alg')}")
+        ui.success(f"Algorithm used is: {header.get('alg')}")
 
 def check_missing_claims(payload):
     required = ['exp', 'iat', 'nbf', 'aud', 'iss']
     for claim in required:
         if claim not in payload:
-            print(f"[!] Missing claim: {claim}")
-    print("[+] Claim check complete.")
+            ui.warn(f"Missing claim: {claim}")
+    ui.success("Claim check complete.")
 
 def check_expired(payload):
     exp = payload.get('exp')
     if exp:
         now = int(time.time())
         if now > int(exp):
-            print("[!] Token is expired.")
+            ui.warn("Token is expired.")
         else:
-            print("[+] Token expiration OK.")
+            ui.success("Token expiration OK.")
 
 def check_long_lifetime(payload):
     exp = payload.get('exp')
@@ -49,9 +50,9 @@ def check_long_lifetime(payload):
         try:
             lifetime = int(exp) - int(iat)
             if lifetime > 3600 * 24 * 7:
-                print(f"[!] Token lifetime unusually long: {lifetime} seconds")
+                ui.warn(f"Token lifetime unusually long: {lifetime} seconds")
             else:
-                print("[+] Token lifetime within normal bounds.")
+                ui.success("Token lifetime within normal bounds.")
         except Exception:
             pass
 
@@ -62,21 +63,21 @@ def check_suspicious_iat(payload):
         try:
             iat = int(iat)
             if iat > now + 300 or iat < now - (3600 * 24 * 365 * 10):
-                print("[!] Suspicious issued-at (iat) timestamp:", iat)
+                ui.warn(f"Suspicious issued-at (iat) timestamp: {iat}")
             else:
-                print("[+] iat timestamp looks reasonable.")
+                ui.success("iat timestamp looks reasonable.")
         except Exception:
-            print("[!] Invalid iat timestamp format.")
+            ui.warn("Invalid iat timestamp format.")
 
 def check_suspicious_kid(header):
     kid = header.get('kid')
     if kid:
         if '..' in kid or '/' in kid:
-            print(f"[!] Suspicious kid value: {kid}")
+            ui.warn(f"Suspicious kid value: {kid}")
 
 def check_rs256_alg_downgrade(header):
     alg = header.get("alg", "")
     if alg.upper() == "RS256":
-        print("[!] Warning: Token uses RS256 (asymmetric). Check if the backend verifies key type correctly.")
-        print("    Possible downgrade to HS256 and signature using public key as HMAC secret.")
-        print("    → Try exploit: jwtek exploit --vuln alg-swap-rs256\n")
+        ui.warn("Warning: Token uses RS256 (asymmetric). Check if the backend verifies key type correctly.")
+        ui.warn("    Possible downgrade to HS256 and signature using public key as HMAC secret.")
+        ui.warn("    → Try exploit: jwtek exploit --vuln alg-swap-rs256\n")

--- a/jwtek/core/ui.py
+++ b/jwtek/core/ui.py
@@ -1,8 +1,52 @@
+"""Console UI helpers with optional color output."""
+
+import os
 from termcolor import cprint
 
-def section(title):
+
+# Determine if colors should be disabled either via environment variable or
+# runtime flag.  The ``JWTEK_NO_COLOR`` env var mirrors the ``--no-color`` CLI
+# option added in ``__main__``.  Tests also modify this flag directly.
+NO_COLOR = os.environ.get("JWTEK_NO_COLOR") == "1"
+
+
+def set_no_color(value: bool) -> None:
+    """Allow disabling coloured output programmatically."""
+    global NO_COLOR
+    NO_COLOR = bool(value)
+
+
+def _cprint(msg: str, color: str = None, attrs=None) -> None:
+    """Wrapper around :func:`termcolor.cprint` respecting NO_COLOR."""
+    if NO_COLOR:
+        print(msg)
+    else:
+        cprint(msg, color, attrs=attrs)
+
+def section(title: str) -> None:
+    """Print a coloured section heading."""
     line = "═" * (len(title) + 4)
     print()
-    cprint(f"╔{line}╗", "cyan")
-    cprint(f"║  {title}  ║", "cyan", attrs=["bold"])
-    cprint(f"╚{line}╝", "cyan")
+    _cprint(f"╔{line}╗", "cyan")
+    _cprint(f"║  {title}  ║", "cyan", attrs=["bold"])
+    _cprint(f"╚{line}╝", "cyan")
+
+
+def info(msg: str) -> None:
+    """Display an informational message."""
+    _cprint(msg, "cyan")
+
+
+def success(msg: str) -> None:
+    """Display a success message."""
+    _cprint(msg, "green")
+
+
+def warn(msg: str) -> None:
+    """Display a warning message."""
+    _cprint(msg, "yellow")
+
+
+def error(msg: str) -> None:
+    """Display an error message."""
+    _cprint(msg, "red")

--- a/jwtek/core/validator.py
+++ b/jwtek/core/validator.py
@@ -1,31 +1,32 @@
 import jwt
 import requests
+from . import ui
 
 def verify_signature_rs256(token, public_key_path):
-    print(f"\n[~] Attempting to verify RS256 signature using: {public_key_path}")
+    ui.info(f"\n[~] Attempting to verify RS256 signature using: {public_key_path}")
     try:
         with open(public_key_path, 'r') as f:
             pubkey = f.read()
 
         decoded = jwt.decode(token, pubkey, algorithms=["RS256"])
-        print("[+] Signature verified successfully! Token is valid.")
-        print("    Payload:", decoded)
+        ui.success("[+] Signature verified successfully! Token is valid.")
+        ui.info(f"    Payload: {decoded}")
 
     except jwt.ExpiredSignatureError:
-        print("[!] Signature is valid but token is expired.")
+        ui.warn("Signature is valid but token is expired.")
     except jwt.InvalidSignatureError:
-        print("[!] Signature is invalid! Token may have been tampered with.")
+        ui.error("Signature is invalid! Token may have been tampered with.")
     except Exception as e:
-        print(f"[!] Error verifying signature: {e}")
+        ui.error(f"Error verifying signature: {e}")
 
 
 def verify_signature_jwks(token, jwks_url):
-    print(f"\n[~] Attempting to verify signature using JWKS: {jwks_url}")
+    ui.info(f"\n[~] Attempting to verify signature using JWKS: {jwks_url}")
     try:
         try:
             from jwt import PyJWKClient
         except Exception:
-            print("[!] PyJWKClient unavailable. JWKS verification not supported.")
+            ui.error("PyJWKClient unavailable. JWKS verification not supported.")
             return
 
         jwk_client = PyJWKClient(jwks_url)
@@ -46,11 +47,11 @@ def verify_signature_jwks(token, jwks_url):
             ],
             options={"verify_aud": False},
         )
-        print("[+] Signature verified successfully via JWKS!")
-        print("    Payload:", decoded)
+        ui.success("[+] Signature verified successfully via JWKS!")
+        ui.info(f"    Payload: {decoded}")
     except jwt.ExpiredSignatureError:
-        print("[!] Signature is valid but token is expired.")
+        ui.warn("Signature is valid but token is expired.")
     except jwt.InvalidSignatureError:
-        print("[!] Signature is invalid! Token may have been tampered with.")
+        ui.error("Signature is invalid! Token may have been tampered with.")
     except Exception as e:
-        print(f"[!] Error verifying signature using JWKS: {e}")
+        ui.error(f"Error verifying signature using JWKS: {e}")

--- a/tests/test_analyze_all_diffs.py
+++ b/tests/test_analyze_all_diffs.py
@@ -19,6 +19,14 @@ sys.modules.setdefault("requests", type("Dummy", (), {})())
 sys.modules.setdefault("tqdm", type("Dummy", (), {"tqdm": lambda x, *a, **k: x})())
 sys.modules.setdefault("termcolor", type("Dummy", (), {"cprint": lambda *a, **k: None})())
 
+# Stub UI helpers to avoid colour output during tests
+import jwtek.core.ui as ui
+ui.info = lambda *a, **k: None
+ui.success = lambda *a, **k: None
+ui.warn = lambda *a, **k: None
+ui.error = lambda *a, **k: None
+ui.section = lambda *a, **k: None
+
 from jwtek.__main__ import analyze_all_from_file
 
 


### PR DESCRIPTION
## Summary
- add UI helpers for colorized output and allow disabling colors
- support global `--no-color` flag in CLI
- refactor modules to use the new helpers
- adjust tests for new UI helpers
- document color usage option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6871ce075bf48327b4070e0d5747ab60