### PR TITLE
Add tabular output for batch analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,14 @@ Use `--no-color` or set `JWTEK_NO_COLOR=1` to disable ANSI colours.
 
 Use `--analyze-all` to extract and analyze every JWT from a file. Differences
 between sequential tokens are displayed automatically at the end of the output.
+Add the `--table` flag to also print a table summarising decoded claims.
 
 ```bash
 python3 jwtek.py analyze --token <JWT>
 python3 jwtek.py analyze --token <JWT> --pubkey ./public.pem --audit
 python3 jwtek.py analyze --token <JWT> --jwks <JWKS_URL>
 python3 jwtek.py analyze --file ./tokens.txt --analyze-all
+python3 jwtek.py analyze --file ./tokens.txt --analyze-all --table
 ```
 
 ### 🔐 Brute-force HS256

--- a/jwtek/__main__.py
+++ b/jwtek/__main__.py
@@ -11,7 +11,7 @@ from jwtek.core import (
     ui,
 )
 
-def analyze_all_from_file(file_path, pubkey=None, jwks_url=None, audit_flag=False, output_json=None):
+def analyze_all_from_file(file_path, pubkey=None, jwks_url=None, audit_flag=False, output_json=None, table_flag=False):
     tokens = extractor.extract_all_jwts_from_file(file_path)
     if not tokens:
         print("[!] No JWTs found in file.")
@@ -72,6 +72,10 @@ def analyze_all_from_file(file_path, pubkey=None, jwks_url=None, audit_flag=Fals
             json.dump(results, f, indent=2)
         print(f"\n[+] Results written to {output_json}")
 
+    if table_flag:
+        flattened = [{**r.get("header", {}), **r.get("payload", {})} for r in results]
+        ui.print_table(flattened)
+
 def main(argv=None):
     parser_cli = argparse.ArgumentParser(
         prog='jwtek',
@@ -90,6 +94,7 @@ def main(argv=None):
     analyze_parser.add_argument('--file', help='Path to file to extract JWT from')
     analyze_parser.add_argument('--analyze-all', action='store_true', help='Extract and analyze all JWTs from file')
     analyze_parser.add_argument('--json-out', help='Write analysis results to JSON file')
+    analyze_parser.add_argument('--table', action='store_true', help='Display results in table format when using --analyze-all')
 
     # === brute-force ===
     brute_parser = subparsers.add_parser('brute-force', help='Brute-force JWT secret for HS256')
@@ -131,6 +136,7 @@ def main(argv=None):
                 jwks_url=args.jwks,
                 audit_flag=args.audit,
                 output_json=args.json_out,
+                table_flag=args.table,
             )
             return
 

--- a/jwtek/core/ui.py
+++ b/jwtek/core/ui.py
@@ -50,3 +50,20 @@ def warn(msg: str) -> None:
 def error(msg: str) -> None:
     """Display an error message."""
     _cprint(msg, "red")
+
+
+def print_table(rows):
+    """Pretty print a list of dictionaries using :mod:`tabulate`."""
+    if not rows:
+        print("(no data)")
+        return
+    try:
+        from tabulate import tabulate
+    except Exception:
+        for row in rows:
+            print(row)
+        return
+
+    headers = sorted({key for row in rows for key in row})
+    table = [[row.get(h, "") for h in headers] for row in rows]
+    print(tabulate(table, headers=headers, tablefmt="github"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyjwt
 tqdm
 termcolor
 requests
+tabulate

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         'tqdm',
         'requests',
         'termcolor',
+        'tabulate',
         # add others as needed
     ],
     entry_points={

--- a/tests/test_analyze_all_diffs.py
+++ b/tests/test_analyze_all_diffs.py
@@ -49,3 +49,20 @@ def test_analyze_all_prints_diffs(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "Diff: token #1 vs token #2" in out
     assert "id: '1' -> '2'" in out
+
+
+def test_analyze_all_table_output(tmp_path, capsys):
+    token1 = forge_token({"id": 1})
+    path = tmp_path / "t.txt"
+    path.write_text(f"{token1}\n")
+
+    # stub tabulate to produce predictable output
+    sys.modules.setdefault(
+        "tabulate",
+        type("Dummy", (), {"tabulate": lambda *a, **k: "TABLE"})(),
+    )
+
+    analyze_all_from_file(str(path), table_flag=True)
+
+    out = capsys.readouterr().out
+    assert "TABLE" in out


### PR DESCRIPTION
## Summary
- add `tabulate` as a dependency
- support printing lists of dictionaries as tables via `ui.print_table`
- allow `analyze --analyze-all --table` to show a table of token data
- document the new option in the README
- test that table output is produced when the flag is used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873cbf48268832791d2cf8f88117311