### PR TITLE
Fix string formatting for exploit messages

### DIFF
--- a/jwtek/core/exploits.py
+++ b/jwtek/core/exploits.py
@@ -40,7 +40,7 @@ def explain_alg_none():
 
 
 def explain_hs256_key_found(secret):
-    ui.warn(f"\n[!] Exploit: HS256 with guessable secret")
+    ui.warn("\n[!] Exploit: HS256 with guessable secret")
     print(f"""
 ➤ Description:
   The JWT is signed with a weak or guessable shared secret. You found it: **{secret}**
@@ -127,7 +127,7 @@ def generate_poc_token(vuln_id, secret=None, jwks_url=None):
         ui.error("[!] Cannot generate PoC: missing secret or invalid vuln ID.")
         return
 
-    ui.success(f"\n[+] PoC Token:")
+    ui.success("\n[+] PoC Token:")
     print(token)
     ui.info("\n[+] Example Usage:")
     print(f'curl -H "Authorization: Bearer {token}" https://target.com/api')


### PR DESCRIPTION
## Summary
- update exploit message to use plain string
- adjust PoC token message format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6873d70183b0832786b7357754ba4c1d