### PR TITLE
Fix bare except in extractor

### DIFF
--- a/jwtek/core/extractor.py
+++ b/jwtek/core/extractor.py
@@ -11,7 +11,7 @@ def extract_from_file(path):
         with open(path, "r") as f:
             content = f.read()
         return extract_jwt_from_text(content)
-    except:
+    except FileNotFoundError:
         return None
     
 def extract_all_jwts_from_file(file_path):


### PR DESCRIPTION
## Summary
- narrow exception handling when reading JWT from file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6873d701a09c8327b5e7a93447cb806e