### PR TITLE
Document JWTEK_WORDLIST_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ of a file path. JWTEK expects these wordlists at the following locations:
 If a preset wordlist isn't found at its location, JWTEK will display an error
 and you can supply your own wordlist path with `--wordlist`.
 
+The base directory for these presets can also be changed by setting the
+`JWTEK_WORDLIST_DIR` environment variable. On Linux this usually points to
+`/usr/share/wordlists` or a similar folder. macOS and Windows users may set the
+variable to their own wordlist directory.
+
 ### 💣 Exploitation Guidance
 
 ```bash


### PR DESCRIPTION
## Summary
- document the `JWTEK_WORDLIST_DIR` environment variable
- explain how macOS/Windows users can specify their own wordlist path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6877de06bf8c83278cb132cdd945650d