### PR TITLE
Add pyproject and wheel build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ different ways:
    ```
    pip3 install -e .
    ```
+4. Build a wheel using [build](https://pypi.org/project/build/)
+   ```
+   python -m build
+   ```
+5. Install the generated wheel
+   ```
+   pip install dist/jwtek-<version>-py3-none-any.whl
+   ```
 ---
 
 ## 🚀 Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jwtek"
+version = "1.0.0"
+description = "JWT Security Analysis & Exploitation Tool"
+readme = "README.md"
+requires-python = ">=3.6"
+authors = [{name = "Parth"}]
+dependencies = [
+    "pyjwt",
+    "tqdm",
+    "requests",
+    "termcolor",
+]
+
+[project.scripts]
+jwtek = "jwtek.__main__:main"

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,32 @@
 from setuptools import setup, find_packages
+import pathlib
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - fallback for Python<3.11
+    import tomli as tomllib
+
+
+def load_project_metadata():
+    """Load project metadata from ``pyproject.toml`` if available."""
+    path = pathlib.Path(__file__).with_name("pyproject.toml")
+    if not path.is_file():
+        return {}
+    with path.open("rb") as f:
+        return tomllib.load(f).get("project", {})
+
+
+project = load_project_metadata()
 
 setup(
-    name='jwtek',
-    version='1.0.0',
-    description='JWT Security Analysis & Exploitation Tool',
-    author='Parth',
+    name=project.get("name", "jwtek"),
+    version=project.get("version", "0.0.0"),
+    description=project.get("description", ""),
+    author=(project.get("authors") or [{}])[0].get("name", ""),
     packages=find_packages(),
-    install_requires=[
-        'pyjwt',
-        'tqdm',
-        'requests',
-        'termcolor',
-        # add others as needed
-    ],
+    install_requires=project.get("dependencies", []),
     entry_points={
-        'console_scripts': [
-            'jwtek = jwtek.__main__:main',
-        ],
+        "console_scripts": [f"{k} = {v}" for k, v in (project.get("scripts", {}).items())],
     },
-    python_requires='>=3.6',
+    python_requires=project.get("requires-python", ">=3.6"),
 )


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with project metadata and build requirements
- parse metadata from `pyproject.toml` inside `setup.py`
- document wheel building and installation in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6877de08547c8327b90564775ecf2ccf