### PR TITLE
Add self-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ different ways:
 ### 4. `forge`
 - Create custom tokens using `none`, `HS256`, or `RS256`
 
+### 5. `update`
+- Upgrade JWTEK to the latest version from GitHub
+
 ---
 
 ## Installation
@@ -123,6 +126,12 @@ jwtek exploit --list
 
 ```bash
 jwtek forge --alg HS256 --payload '{"admin": true}' --secret secret
+```
+
+### ⬆️ Update JWTEK
+
+```bash
+jwtek update
 ```
 
 

--- a/jwtek/__main__.py
+++ b/jwtek/__main__.py
@@ -6,6 +6,7 @@ from jwtek.core import (
     exploits,
     validator,
     forge,
+    updater,
     audit,
     extractor,
     ui,
@@ -116,6 +117,9 @@ def main(argv=None):
     forge_parser.add_argument('--privkey', help='Path to RSA private key (for RS256/ES256/PS256)')
     forge_parser.add_argument('--kid', help='Optional kid header value')
 
+    # === update ===
+    update_parser = subparsers.add_parser('update', help='Update JWTEK from GitHub')
+
 
     args = parser_cli.parse_args()
     if getattr(args, 'no_color', False):
@@ -207,6 +211,9 @@ def main(argv=None):
             privkey_path=args.privkey,
             kid=args.kid,
         )
+
+    elif args.command == 'update':
+        updater.update_tool()
 
     else:
         parser_cli.print_help()

--- a/jwtek/core/updater.py
+++ b/jwtek/core/updater.py
@@ -1,0 +1,14 @@
+import subprocess
+from . import ui
+
+
+def update_tool(repo_url="https://github.com/parthmishra24/JWTek.git", branch="main"):
+    """Update JWTEK from the specified Git repository."""
+    cmd = ["pip", "install", "--upgrade", f"git+{repo_url}@{branch}"]
+    ui.info(f"[~] Updating JWTEK from {repo_url}@{branch}...")
+    try:
+        subprocess.check_call(cmd)
+        ui.success("[+] JWTEK updated successfully.")
+    except Exception as exc:
+        ui.error(f"[!] Failed to update JWTEK: {exc}")
+

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,23 @@
+import jwtek.core.updater as updater
+
+
+def test_update_tool_runs_pip(monkeypatch):
+    calls = {}
+
+    def fake_check_call(cmd):
+        calls['cmd'] = cmd
+
+    monkeypatch.setattr(updater.subprocess, 'check_call', fake_check_call)
+    monkeypatch.setattr(updater.ui, 'info', lambda *a, **k: None)
+    monkeypatch.setattr(updater.ui, 'success', lambda *a, **k: None)
+    monkeypatch.setattr(updater.ui, 'error', lambda *a, **k: None)
+
+    updater.update_tool()
+
+    assert calls['cmd'] == [
+        'pip',
+        'install',
+        '--upgrade',
+        'git+https://github.com/parthmishra24/JWTek.git@main',
+    ]
+


### PR DESCRIPTION
## Summary
- allow JWTEK to update itself from GitHub with a new `update` command
- implement `core.updater` helper
- test that the update command invokes pip correctly

------
https://chatgpt.com/codex/tasks/task_b_6877e1f745b08327b39b41b687bfd246