### PR TITLE
Add break-system-packages flag to updater

### DIFF
--- a/jwtek/core/updater.py
+++ b/jwtek/core/updater.py
@@ -11,6 +11,7 @@ def update_tool(repo_url: str = "https://github.com/parthmishra24/JWTek.git", br
         "pip",
         "install",
         "--upgrade",
+        "--break-system-packages",
         f"git+{repo_url}@{branch}",
     ]
     try:

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -15,6 +15,7 @@ def test_update_tool_runs_pip(monkeypatch):
     updater.update_tool(repo_url='https://github.com/example/repo.git', branch='dev')
     assert calls['cmd'] == [
         'python3', '-m', 'pip', 'install', '--upgrade',
+        '--break-system-packages',
         'git+https://github.com/example/repo.git@dev'
     ]
 


### PR DESCRIPTION
## Summary
- support pip `--break-system-packages` flag when updating
- adjust tests for new pip command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6877ea3f81dc832790853c8cdb401d70