### PR TITLE
Update install instructions to use go

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ different ways:
    ```
    cd JWTek
    ```
-3. Run the pip command
-   ```
-   python -m pip install -e .
+3. Install using Go
+   ```bash
+   go install github.com/parthmishra24/JWTek@latest
    ```
 ---
 

--- a/jwtek/core/updater.py
+++ b/jwtek/core/updater.py
@@ -2,17 +2,13 @@ import subprocess
 from . import ui
 
 
-def update_tool(repo_url: str = "https://github.com/parthmishra24/JWTek.git", branch: str = "main") -> None:
-    """Update JWTEK from the specified Git repository."""
-    ui.info(f"[~] Updating JWTEK from {repo_url}@{branch}...")
+def update_tool(repo_url: str = "github.com/parthmishra24/JWTek", version: str = "latest") -> None:
+    """Update JWTEK using Go."""
+    ui.info(f"[~] Updating JWTEK from {repo_url}@{version}...")
     cmd = [
-        "python3",
-        "-m",
-        "pip",
+        "go",
         "install",
-        "--upgrade",
-        "--break-system-packages",
-        f"git+{repo_url}@{branch}",
+        f"{repo_url}@{version}",
     ]
     try:
         subprocess.check_call(cmd)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,7 +1,7 @@
 import jwtek.core.updater as updater
 
 
-def test_update_tool_runs_pip(monkeypatch):
+def test_update_tool_runs_go(monkeypatch):
     calls = {}
 
     def fake_check_call(cmd):
@@ -12,10 +12,8 @@ def test_update_tool_runs_pip(monkeypatch):
     monkeypatch.setattr(updater.ui, 'success', lambda *a, **k: None)
     monkeypatch.setattr(updater.ui, 'error', lambda *a, **k: None)
 
-    updater.update_tool(repo_url='https://github.com/example/repo.git', branch='dev')
+    updater.update_tool(repo_url='github.com/example/repo', version='dev')
     assert calls['cmd'] == [
-        'python3', '-m', 'pip', 'install', '--upgrade',
-        '--break-system-packages',
-        'git+https://github.com/example/repo.git@dev'
+        'go', 'install', 'github.com/example/repo@dev'
     ]
 


### PR DESCRIPTION
## Summary
- update README to instruct installing with `go install`
- switch update command to use Go
- adjust tests for Go updater

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68789c964eac83278301c098a5dadcd2