### PR TITLE
Expose repo/branch options via CLI update

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ jwtek forge --alg HS256 --payload '{"admin": true}' --secret secret
 jwtek update
 ```
 
+You can optionally specify a custom repository and branch:
+
+```bash
+jwtek update --repo https://github.com/example/JWTek.git --branch dev
+```
+
 
 ## 🧠 Author
 

--- a/jwtek/__main__.py
+++ b/jwtek/__main__.py
@@ -112,6 +112,16 @@ def main(argv=None):
 
     # === update ===
     update_parser = subparsers.add_parser('update', help='Update JWTEK from GitHub')
+    update_parser.add_argument(
+        '--repo',
+        default='https://github.com/parthmishra24/JWTek.git',
+        help='Git repository to install from',
+    )
+    update_parser.add_argument(
+        '--branch',
+        default='main',
+        help='Repository branch to install',
+    )
 
 
     args = parser_cli.parse_args()
@@ -201,7 +211,7 @@ def main(argv=None):
         )
 
     elif args.command == 'update':
-        updater.update_tool()
+        updater.update_tool(repo_url=args.repo, branch=args.branch)
     else:
         parser_cli.print_help()
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -19,3 +19,27 @@ def test_update_tool_runs_pip(monkeypatch):
         'git+https://github.com/example/repo.git@dev'
     ]
 
+
+def test_update_cli_forwards_args(monkeypatch):
+    import jwtek.__main__ as cli
+
+    called = {}
+
+    def fake_update_tool(repo_url, branch):
+        called['repo'] = repo_url
+        called['branch'] = branch
+
+    monkeypatch.setattr(cli.updater, 'update_tool', fake_update_tool)
+
+    import sys
+    monkeypatch.setattr(sys, 'argv', [
+        'jwtek', 'update', '--repo', 'https://github.com/example/repo.git', '--branch', 'dev'
+    ])
+
+    cli.main()
+
+    assert called == {
+        'repo': 'https://github.com/example/repo.git',
+        'branch': 'dev',
+    }
+


### PR DESCRIPTION
## Summary
- extend CLI `update` command with `--repo` and `--branch` options
- forward these options to `updater.update_tool`
- test CLI forwarding behaviour
- document new flags in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6878c1dca62883278eef3a9e27f10200