### PR TITLE
Improve updater error handling

### DIFF
--- a/jwtek/core/updater.py
+++ b/jwtek/core/updater.py
@@ -15,8 +15,11 @@ def update_tool(repo_url: str = "https://github.com/parthmishra24/JWTek.git", br
         f"git+{repo_url}@{branch}",
     ]
     try:
-        subprocess.check_call(cmd)
-        ui.success("[+] JWTEK updated successfully.")
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode == 0:
+            ui.success("[+] JWTEK updated successfully.")
+        else:
+            ui.error(f"[!] Failed to update JWTEK: {result.stderr}")
     except Exception as exc:
         ui.error(f"[!] Failed to update JWTEK: {exc}")
 

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -4,10 +4,15 @@ import jwtek.core.updater as updater
 def test_update_tool_runs_pip(monkeypatch):
     calls = {}
 
-    def fake_check_call(cmd):
-        calls['cmd'] = cmd
+    class FakeResult:
+        returncode = 0
+        stderr = ''
 
-    monkeypatch.setattr(updater.subprocess, 'check_call', fake_check_call)
+    def fake_run(cmd, capture_output=True, text=True):
+        calls['cmd'] = cmd
+        return FakeResult()
+
+    monkeypatch.setattr(updater.subprocess, 'run', fake_run)
     monkeypatch.setattr(updater.ui, 'info', lambda *a, **k: None)
     monkeypatch.setattr(updater.ui, 'success', lambda *a, **k: None)
     monkeypatch.setattr(updater.ui, 'error', lambda *a, **k: None)
@@ -18,4 +23,27 @@ def test_update_tool_runs_pip(monkeypatch):
         '--break-system-packages',
         'git+https://github.com/example/repo.git@dev'
     ]
+
+
+def test_update_tool_prints_stderr(monkeypatch):
+    messages = {}
+
+    class FakeResult:
+        returncode = 1
+        stderr = 'boom'
+
+    def fake_run(cmd, capture_output=True, text=True):
+        return FakeResult()
+
+    def fake_error(msg):
+        messages['msg'] = msg
+
+    monkeypatch.setattr(updater.subprocess, 'run', fake_run)
+    monkeypatch.setattr(updater.ui, 'info', lambda *a, **k: None)
+    monkeypatch.setattr(updater.ui, 'success', lambda *a, **k: None)
+    monkeypatch.setattr(updater.ui, 'error', fake_error)
+
+    updater.update_tool(repo_url='https://github.com/example/repo.git', branch='dev')
+
+    assert 'boom' in messages.get('msg', '')
 


### PR DESCRIPTION
## Summary
- run `subprocess` using `run()` so stderr can be captured
- output stderr when update fails
- update updater tests for new subprocess behavior
- add a new test verifying stderr is shown on error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6878c1dd75ac8327af44994dbc647ccc