### PR TITLE
Update updater flag logic for pip 23+

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ jwtek forge --alg HS256 --payload '{"admin": true}' --secret secret
 jwtek update
 ```
 
+The command uses `pip install --upgrade` and adds `--break-system-packages`
+when running with pip 23 or newer.
+
 
 ## 🧠 Author
 

--- a/jwtek/core/updater.py
+++ b/jwtek/core/updater.py
@@ -1,5 +1,18 @@
 import subprocess
+import re
+from pip import __version__ as pip_version
 from . import ui
+
+
+def _supports_break_system_packages(version: str | None = None) -> bool:
+    """Return True if pip version is >= 23.0."""
+    if version is None:
+        version = pip_version
+    match = re.match(r"^(\d+)\.(\d+)", version)
+    if not match:
+        return False
+    major, minor = int(match.group(1)), int(match.group(2))
+    return (major, minor) >= (23, 0)
 
 
 def update_tool(repo_url: str = "https://github.com/parthmishra24/JWTek.git", branch: str = "main") -> None:
@@ -11,9 +24,10 @@ def update_tool(repo_url: str = "https://github.com/parthmishra24/JWTek.git", br
         "pip",
         "install",
         "--upgrade",
-        "--break-system-packages",
-        f"git+{repo_url}@{branch}",
     ]
+    if _supports_break_system_packages():
+        cmd.append("--break-system-packages")
+    cmd.append(f"git+{repo_url}@{branch}")
     try:
         subprocess.check_call(cmd)
         ui.success("[+] JWTEK updated successfully.")

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,7 +1,7 @@
 import jwtek.core.updater as updater
 
 
-def test_update_tool_runs_pip(monkeypatch):
+def _run_update(monkeypatch, version):
     calls = {}
 
     def fake_check_call(cmd):
@@ -11,11 +11,25 @@ def test_update_tool_runs_pip(monkeypatch):
     monkeypatch.setattr(updater.ui, 'info', lambda *a, **k: None)
     monkeypatch.setattr(updater.ui, 'success', lambda *a, **k: None)
     monkeypatch.setattr(updater.ui, 'error', lambda *a, **k: None)
+    monkeypatch.setattr(updater, 'pip_version', version)
 
     updater.update_tool(repo_url='https://github.com/example/repo.git', branch='dev')
-    assert calls['cmd'] == [
+    return calls['cmd']
+
+
+def test_update_tool_includes_flag_for_new_pip(monkeypatch):
+    cmd = _run_update(monkeypatch, '23.1')
+    assert cmd == [
         'python3', '-m', 'pip', 'install', '--upgrade',
         '--break-system-packages',
+        'git+https://github.com/example/repo.git@dev'
+    ]
+
+
+def test_update_tool_omits_flag_for_old_pip(monkeypatch):
+    cmd = _run_update(monkeypatch, '22.3')
+    assert cmd == [
+        'python3', '-m', 'pip', 'install', '--upgrade',
         'git+https://github.com/example/repo.git@dev'
     ]
 


### PR DESCRIPTION
## Summary
- use pip.__version__ to check if `--break-system-packages` is supported
- only pass the flag to `pip install` when pip>=23.0
- test both branches of this logic
- document pip version behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6878c1deb6448327a3b989516f1df2a7