### PR TITLE
Add header security checks and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ different ways:
 
 - Static analysis of JWTs with optional RS256 signature verification
 - Detects `alg: none`, weak algorithms, missing or expired claims
+- Flags `jku`/`x5u` headers and unusual `kid` patterns
 - Audits claims for potential privilege escalation
 - RS256 → HS256 downgrade detection
 - Extracts tokens from files and supports batch analysis
@@ -89,6 +90,8 @@ jwtek analyze --file ./tokens.txt --analyze-all
 jwtek exploit --vuln alg-none
 jwtek exploit --vuln hs256-key-found --secret secret123
 jwtek exploit --vuln alg-swap-rs256
+jwtek exploit --vuln jku-header
+jwtek exploit --vuln suspicious-kid
 ```
 
 ```bash

--- a/jwtek/core/exploits.py
+++ b/jwtek/core/exploits.py
@@ -82,6 +82,37 @@ def explain_rs256_downgrade():
 """)
 
 
+def explain_jku_header():
+    ui.warn("\n[!] Exploit: jku header manipulation")
+    print(
+        """
+➤ Description:
+  The 'jku' header references a JWKS URL. If the application fetches this URL
+  without validation, an attacker can host a malicious JWKS and sign tokens.
+
+➤ How to exploit:
+  1. Host your own JWKS endpoint returning your key.
+  2. Set 'jku' to the endpoint and sign the JWT with the matching private key.
+  3. If trusted, the server will accept your token.
+"""
+    )
+
+
+def explain_suspicious_kid():
+    ui.warn("\n[!] Exploit: malicious kid value")
+    print(
+        """
+➤ Description:
+  Some systems load keys from disk based on the 'kid' header. Using path
+  traversal ("../") or a URL may let you control which key is loaded.
+
+➤ Tip:
+  Try referencing a file or URL you control as the kid value to supply your
+  own signing key.
+"""
+    )
+
+
 def explain_exploit(vuln_id, **kwargs):
     if vuln_id == "alg-none":
         explain_alg_none()
@@ -93,6 +124,10 @@ def explain_exploit(vuln_id, **kwargs):
             explain_hs256_key_found(secret)
     elif vuln_id == "alg-swap-rs256":
         explain_rs256_downgrade()
+    elif vuln_id == "jku-header":
+        explain_jku_header()
+    elif vuln_id == "suspicious-kid":
+        explain_suspicious_kid()
     else:
         ui.info(f"[~] No exploit guidance available for: {vuln_id}")
 
@@ -102,6 +137,8 @@ def list_available_exploits():
     print("  - alg-none           → No signature verification")
     print("  - hs256-key-found    → HMAC key discovered via brute-force")
     print("  - alg-swap-rs256     → RS256 to HS256 downgrade attack")
+    print("  - jku-header         → Untrusted JWKS URL usage")
+    print("  - suspicious-kid     → Path traversal or remote kid value")
 
 
 # === POC GENERATOR ===

--- a/jwtek/core/static_analysis.py
+++ b/jwtek/core/static_analysis.py
@@ -11,6 +11,7 @@ def run_all_checks(header, payload):
     check_long_lifetime(payload)
     check_suspicious_iat(payload)
     check_rs256_alg_downgrade(header)
+    check_jku_x5u(header)
     check_suspicious_kid(header)
 
 def check_alg_none(header):
@@ -72,8 +73,17 @@ def check_suspicious_iat(payload):
 def check_suspicious_kid(header):
     kid = header.get('kid')
     if kid:
-        if '..' in kid or '/' in kid:
+        patterns = ['..', '/', 'http://', 'https://']
+        if any(p in kid for p in patterns):
             ui.warn(f"Suspicious kid value: {kid}")
+
+def check_jku_x5u(header):
+    jku = header.get('jku')
+    x5u = header.get('x5u')
+    if jku:
+        ui.warn(f"jku header present: {jku}")
+    if x5u:
+        ui.warn(f"x5u header present: {x5u}")
 
 def check_rs256_alg_downgrade(header):
     alg = header.get("alg", "")

--- a/tests/test_static_analysis_headers.py
+++ b/tests/test_static_analysis_headers.py
@@ -1,0 +1,23 @@
+import jwtek.core.static_analysis as sa
+from unittest import mock
+
+def test_check_jku_warns():
+    header = {'jku': 'http://evil.com/jwks.json'}
+    with mock.patch('jwtek.core.ui.warn') as warn:
+        sa.check_jku_x5u(header)
+        warn.assert_called()
+        assert 'jku' in warn.call_args[0][0]
+
+def test_check_x5u_warns():
+    header = {'x5u': 'http://evil.com/cert.pem'}
+    with mock.patch('jwtek.core.ui.warn') as warn:
+        sa.check_jku_x5u(header)
+        warn.assert_called()
+        assert 'x5u' in warn.call_args[0][0]
+
+def test_suspicious_kid_url():
+    header = {'kid': 'http://attacker/key'}
+    with mock.patch('jwtek.core.ui.warn') as warn:
+        sa.check_suspicious_kid(header)
+        warn.assert_called()
+        assert 'kid' in warn.call_args[0][0]


### PR DESCRIPTION
## Summary
- detect `jku`/`x5u` headers and more suspicious `kid` values
- describe possible attacks for these headers in `exploits.py`
- mention the new checks and exploit examples in README
- add unit tests for the new static analysis logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6879348e7ee48327b913335867a1131a