### PR TITLE
Add brute-force secret discovery

### DIFF
--- a/jwtek/__main__.py
+++ b/jwtek/__main__.py
@@ -9,6 +9,7 @@ from jwtek.core import (
     forge,
     audit,
     extractor,
+    bruteforce,
     ui,
 )
 
@@ -222,6 +223,11 @@ def main(argv=None):
     forge_parser.add_argument('--privkey', help='Path to RSA private key (for RS256/ES256/PS256)')
     forge_parser.add_argument('--kid', help='Optional kid header value')
 
+    # === brute ===
+    brute_parser = subparsers.add_parser('brute', help='Brute force HS* secret key')
+    brute_parser.add_argument('--token', required=True, help='JWT token to crack')
+    brute_parser.add_argument('--wordlist', required=True, help='Path to wordlist of secrets')
+
     # === update ===
     subparsers.add_parser('update', help='Update JWTEK to the latest version')
 
@@ -311,6 +317,9 @@ def main(argv=None):
             privkey_path=args.privkey,
             kid=args.kid,
         )
+
+    elif args.command == 'brute':
+        bruteforce.bruteforce_hmac_secret(args.token, args.wordlist)
 
     elif args.command == 'update':
         update_jwtek()

--- a/jwtek/core/bruteforce.py
+++ b/jwtek/core/bruteforce.py
@@ -1,0 +1,29 @@
+import jwt
+from . import ui
+
+
+def bruteforce_hmac_secret(token, wordlist_path):
+    """Brute force the HMAC secret for a JWT using a wordlist."""
+    try:
+        with open(wordlist_path, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                secret = line.strip()
+                if not secret:
+                    continue
+                try:
+                    jwt.decode(
+                        token,
+                        secret,
+                        algorithms=["HS256", "HS384", "HS512"],
+                        options={"verify_signature": True, "verify_aud": False},
+                    )
+                    ui.success(f"[+] Secret found: {secret}")
+                    return secret
+                except Exception:
+                    continue
+    except FileNotFoundError:
+        ui.error(f"Wordlist not found: {wordlist_path}")
+        return None
+
+    ui.error("Secret not found in wordlist.")
+    return None

--- a/tests/test_bruteforce.py
+++ b/tests/test_bruteforce.py
@@ -1,0 +1,53 @@
+import sys
+import types
+
+# Provide dummy termcolor before importing ui
+sys.modules.setdefault(
+    "termcolor",
+    type("Dummy", (), {"cprint": lambda *a, **k: None})(),
+)
+
+from jwtek.core import ui
+
+# Stub ui functions to suppress output
+ui.info = lambda *a, **k: None
+ui.success = lambda *a, **k: None
+ui.warn = lambda *a, **k: None
+ui.error = lambda *a, **k: None
+ui.section = lambda *a, **k: None
+
+# Dummy jwt module (may already exist from other tests)
+class _DummyException(Exception):
+    pass
+
+jwt_mod = sys.modules.setdefault("jwt", types.ModuleType("jwt"))
+exc_mod = sys.modules.setdefault("jwt.exceptions", types.ModuleType("jwt.exceptions"))
+exc_mod.InvalidSignatureError = _DummyException
+exc_mod.DecodeError = _DummyException
+jwt_mod.exceptions = exc_mod
+
+
+def make_decode(correct_secret):
+    def _decode(token, secret, algorithms=None, options=None):
+        if secret == correct_secret:
+            return {"msg": "ok"}
+        raise _DummyException
+    return _decode
+jwt_mod.decode = make_decode("s3cr3t")
+
+from jwtek.core import bruteforce
+
+
+def test_bruteforce_success(tmp_path):
+    wordlist = tmp_path / "wl.txt"
+    wordlist.write_text("foo\ns3cr3t\nbar\n")
+    secret = bruteforce.bruteforce_hmac_secret("token", str(wordlist))
+    assert secret == "s3cr3t"
+
+
+def test_bruteforce_failure(tmp_path):
+    wordlist = tmp_path / "wl.txt"
+    wordlist.write_text("foo\nbar\n")
+    secret = bruteforce.bruteforce_hmac_secret("token", str(wordlist))
+    assert secret is None
+


### PR DESCRIPTION
## Summary
- implement `bruteforce_hmac_secret` helper and wire up new `brute` subcommand
- extend CLI to parse `jwtek brute --token ... --wordlist ...`
- add tests for successful and failed brute force attempts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687938c06ea083278c1bcf529f99c203