### PR TITLE
Add HMAC signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ different ways:
 ### 1. `analyze`
 - Decode a token and run static checks
 - Optional `--pubkey` to verify RS256 signatures
+- Optional `--secret` to verify HS256/384/512 signatures
 - `--audit` highlights suspicious privilege claims
 - Tokens can also be extracted from files with `--file` or analysed in batch
   using `--analyze-all`
@@ -50,7 +51,7 @@ different ways:
 
 ## 🚀 Features
 
-- Static analysis of JWTs with optional RS256 signature verification
+- Static analysis of JWTs with optional RS256 or HS256/384/512 signature verification
 - Detects `alg: none`, weak algorithms, missing or expired claims
 - Flags `jku`/`x5u` headers and unusual `kid` patterns
 - Audits claims for potential privilege escalation
@@ -80,6 +81,7 @@ between sequential tokens are displayed automatically at the end of the output.
 jwtek analyze --token <JWT>
 jwtek analyze --token <JWT> --pubkey ./public.pem --audit
 jwtek analyze --token <JWT> --jwks <JWKS_URL>
+jwtek analyze --token <JWT> --secret mysecret
 jwtek analyze --file ./tokens.txt --analyze-all
 ```
 

--- a/jwtek/__main__.py
+++ b/jwtek/__main__.py
@@ -13,7 +13,7 @@ from jwtek.core import (
     ui,
 )
 
-def analyze_all_from_file(file_path, pubkey=None, jwks_url=None, audit_flag=False, output_json=None):
+def analyze_all_from_file(file_path, pubkey=None, jwks_url=None, secret=None, audit_flag=False, output_json=None):
     tokens = extractor.extract_all_jwts_from_file(file_path)
     if not tokens:
         print("[!] No JWTs found in file.")
@@ -39,6 +39,9 @@ def analyze_all_from_file(file_path, pubkey=None, jwks_url=None, audit_flag=Fals
 
         if jwks_url:
             validator.verify_signature_jwks(token, jwks_url)
+
+        if secret:
+            validator.verify_signature_hmac(token, secret)
 
         if audit_flag:
             audit.audit_claims(payload)
@@ -199,6 +202,7 @@ def main(argv=None):
     analyze_parser.add_argument('--token', required=False, help='JWT string to analyze')
     analyze_parser.add_argument('--pubkey', help='Optional path to public key (PEM) for signature verification')
     analyze_parser.add_argument('--jwks', help='URL to JWKS for signature verification')
+    analyze_parser.add_argument('--secret', help='Shared secret for HS256/384/512 verification')
     analyze_parser.add_argument('--audit', action='store_true', help='Audit JWT claims for privilege abuse')
     analyze_parser.add_argument('--file', help='Path to file to extract JWT from')
     analyze_parser.add_argument('--analyze-all', action='store_true', help='Extract and analyze all JWTs from file')
@@ -244,6 +248,7 @@ def main(argv=None):
                 args.file,
                 pubkey=args.pubkey,
                 jwks_url=args.jwks,
+                secret=args.secret,
                 audit_flag=args.audit,
                 output_json=args.json_out,
             )
@@ -282,6 +287,9 @@ def main(argv=None):
 
         if args.jwks:
             validator.verify_signature_jwks(token, args.jwks)
+
+        if args.secret:
+            validator.verify_signature_hmac(token, args.secret)
 
         if args.audit:
             audit.audit_claims(payload)

--- a/jwtek/core/validator.py
+++ b/jwtek/core/validator.py
@@ -54,3 +54,23 @@ def verify_signature_jwks(token, jwks_url):
         ui.error("Signature is invalid! Token may have been tampered with.")
     except Exception as e:
         ui.error(f"Error verifying signature using JWKS: {e}")
+
+
+def verify_signature_hmac(token, secret):
+    """Verify an HS256/384/512 signed token using the provided secret."""
+    ui.info("\n[~] Attempting to verify HMAC signature")
+    try:
+        decoded = jwt.decode(
+            token,
+            secret,
+            algorithms=["HS256", "HS384", "HS512"],
+            options={"verify_aud": False},
+        )
+        ui.success("[+] Signature verified successfully!")
+        ui.info(f"    Payload: {decoded}")
+    except jwt.ExpiredSignatureError:
+        ui.warn("Signature is valid but token is expired.")
+    except jwt.InvalidSignatureError:
+        ui.error("Signature is invalid! Token may have been tampered with.")
+    except Exception as e:
+        ui.error(f"Error verifying signature: {e}")

--- a/tests/test_validator_hmac.py
+++ b/tests/test_validator_hmac.py
@@ -1,0 +1,52 @@
+import sys
+import types
+from unittest import mock
+
+# Provide dummy termcolor before importing ui
+sys.modules.setdefault("termcolor", type("Dummy", (), {"cprint": lambda *a, **k: None})())
+
+from jwtek.core import ui
+
+# Silence ui output in tests
+ui.info = lambda *a, **k: None
+ui.success = lambda *a, **k: None
+ui.warn = lambda *a, **k: None
+ui.error = lambda *a, **k: None
+ui.section = lambda *a, **k: None
+
+# Dummy jwt module for validator
+class _DummyException(Exception):
+    pass
+
+jwt_mod = sys.modules.setdefault("jwt", types.ModuleType("jwt"))
+exc_mod = sys.modules.setdefault("jwt.exceptions", types.ModuleType("jwt.exceptions"))
+exc_mod.InvalidSignatureError = _DummyException
+jwt_exp = type("_Exp", (Exception,), {})
+exc_mod.ExpiredSignatureError = jwt_exp
+jwt_mod.InvalidSignatureError = _DummyException
+jwt_mod.ExpiredSignatureError = jwt_exp
+jwt_mod.exceptions = exc_mod
+
+
+def make_decode(correct):
+    def _decode(token, key, algorithms=None, options=None):
+        if key == correct:
+            return {"ok": True}
+        raise _DummyException
+    return _decode
+
+from jwtek.core import validator
+
+
+def test_verify_signature_hmac_success():
+    jwt_mod.decode = make_decode("secret")
+    with mock.patch("jwtek.core.ui.success") as success:
+        validator.verify_signature_hmac("token", "secret")
+        success.assert_called()
+
+
+def test_verify_signature_hmac_failure():
+    jwt_mod.decode = make_decode("secret")
+    with mock.patch("jwtek.core.ui.error") as err:
+        validator.verify_signature_hmac("token", "wrong")
+        err.assert_called()


### PR DESCRIPTION
## Summary
- allow providing `--secret` to `jwtek analyze`
- implement `verify_signature_hmac`
- call the new validator when analyzing tokens or files
- document HS256 verification in features and usage
- test HMAC verification

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68793d437b908327b785fa3ce224bb18