### PR TITLE
feat: allow forging from existing tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ different ways:
 - Get exploitation tips, generate PoC tokens, or attempt auth bypass testing
 
 ### 3. `forge`
-- Create custom tokens using `none`, `HS256`, or `RS256`
+- Create or convert tokens using `none`, `HS256`, or `RS256`
 
 
 ---
@@ -57,7 +57,7 @@ different ways:
 - Audits claims for potential privilege escalation
 - RS256 → HS256 downgrade detection
 - Extracts tokens from files and supports batch analysis
-- Forge custom tokens using `none`, `HS256`, or `RS256`
+- Forge custom tokens or convert existing ones using `none`, `HS256`, or `RS256`
 - Guided exploitation advice with PoCs and bypass testing
 - Extendable and modular structure
 - Colored console output for readability (disable with `--no-color` or `JWTEK_NO_COLOR=1`)
@@ -109,11 +109,14 @@ jwtek exploit --list
 
 ### ✨ Forge a JWT
 
-The `--payload` option accepts a JSON string describing the claims for the token.
-For example:
+The `forge` command can create a token from a JSON payload or convert an existing JWT using `--token`.
 
 ```bash
+# Forge from a payload
 jwtek forge --alg HS256 --payload '{"sub":"1234567890","name":"John Doe","admin":true}' --secret secret
+
+# Convert an RS256 token to alg none
+jwtek forge --alg none --token <JWT>
 ```
 
 ### 🔄 Update JWTEK

--- a/jwtek/__main__.py
+++ b/jwtek/__main__.py
@@ -226,12 +226,13 @@ def main(argv=None):
     forge_parser.add_argument('--alg', required=True, help="Algorithm to use (HS256, RS256, ES256, PS256, none)")
     forge_parser.add_argument(
         '--payload',
-        required=True,
+        required=False,
         help=(
             "JSON payload string, e.g. '{\"sub\":\"1234567890\","
-            "\"name\":\"John Doe\",\"admin\":true}'"
+            "\"name\":\"John Doe\",\"admin\":true}' (optional if --token is provided)"
         ),
     )
+    forge_parser.add_argument('--token', help='Existing JWT to convert/re-sign')
     forge_parser.add_argument('--secret', help="Secret key for HS256 (optional)")
     forge_parser.add_argument('--pubkey', help='Path to RSA public key (for RS256)')
     forge_parser.add_argument('--privkey', help='Path to RSA private key (for RS256/ES256/PS256)')
@@ -337,9 +338,13 @@ def main(argv=None):
             print("[!] Use --vuln to specify a vulnerability ID or --list to see options.")
 
     elif args.command == 'forge':
+        if (args.payload and args.token) or (not args.payload and not args.token):
+            print("[!] Provide either --payload or --token.")
+            return
         forge.forge_jwt(
             alg=args.alg,
             payload_str=args.payload,
+            token=args.token,
             secret=args.secret,
             privkey_path=args.privkey,
             kid=args.kid,


### PR DESCRIPTION
## Summary
- support `jwtek forge` from existing `--token` or `--payload`
- extend `forge_jwt` to rebuild tokens under new algorithm
- document conversion capabilities and add tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b04073acfc83278b22928f7eab39ef