### PR TITLE
Format timestamps with space separator

### DIFF
--- a/jwtek/core/parser.py
+++ b/jwtek/core/parser.py
@@ -13,7 +13,7 @@ def _format_timestamps(payload):
     for claim in ("iat", "exp", "nbf"):
         if claim in formatted:
             try:
-                formatted[claim] = datetime.fromtimestamp(int(formatted[claim])).isoformat()
+                formatted[claim] = datetime.fromtimestamp(int(formatted[claim])).strftime("%Y-%m-%d %H:%M:%S")
             except Exception:
                 pass
     return formatted

--- a/jwtek/core/static_analysis.py
+++ b/jwtek/core/static_analysis.py
@@ -42,7 +42,7 @@ def check_expired(payload):
         now = int(time.time())
         try:
             exp_int = int(exp)
-            exp_human = datetime.fromtimestamp(exp_int).isoformat()
+            exp_human = datetime.fromtimestamp(exp_int).strftime("%Y-%m-%d %H:%M:%S")
             if now > exp_int:
                 ui.warn(f"Token is expired (exp: {exp_human}).")
             else:
@@ -58,8 +58,8 @@ def check_long_lifetime(payload):
             exp_int = int(exp)
             iat_int = int(iat)
             lifetime = exp_int - iat_int
-            exp_human = datetime.fromtimestamp(exp_int).isoformat()
-            iat_human = datetime.fromtimestamp(iat_int).isoformat()
+            exp_human = datetime.fromtimestamp(exp_int).strftime("%Y-%m-%d %H:%M:%S")
+            iat_human = datetime.fromtimestamp(iat_int).strftime("%Y-%m-%d %H:%M:%S")
             if lifetime > 3600 * 24 * 7:
                 ui.warn(f"Token lifetime unusually long: {lifetime} seconds ({iat_human} -> {exp_human})")
             else:
@@ -73,7 +73,7 @@ def check_suspicious_iat(payload):
         now = int(time.time())
         try:
             iat_int = int(iat)
-            iat_human = datetime.fromtimestamp(iat_int).isoformat()
+            iat_human = datetime.fromtimestamp(iat_int).strftime("%Y-%m-%d %H:%M:%S")
             if iat_int > now + 300 or iat_int < now - (3600 * 24 * 365 * 10):
                 ui.warn(f"Suspicious issued-at (iat) timestamp: {iat_human}")
             else:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -33,5 +33,5 @@ def test_pretty_print_jwt_formats_timestamps(capsys):
     payload = {"iat": ts, "exp": ts + 10, "nbf": ts}
     parser.pretty_print_jwt(header, payload, "sig")
     out = capsys.readouterr().out
-    human = datetime.fromtimestamp(ts).isoformat()
+    human = datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
     assert human in out

--- a/tests/test_static_analysis_claims.py
+++ b/tests/test_static_analysis_claims.py
@@ -8,7 +8,7 @@ def test_check_expired_includes_timestamp():
     with mock.patch('jwtek.core.ui.warn') as warn, mock.patch('time.time', return_value=100):
         sa.check_expired(payload)
         warn.assert_called()
-        assert datetime.fromtimestamp(50).isoformat() in warn.call_args[0][0]
+        assert datetime.fromtimestamp(50).strftime("%Y-%m-%d %H:%M:%S") in warn.call_args[0][0]
 
 
 def test_check_long_lifetime_includes_timestamps():
@@ -19,8 +19,8 @@ def test_check_long_lifetime_includes_timestamps():
         sa.check_long_lifetime(payload)
         warn.assert_called()
         msg = warn.call_args[0][0]
-        assert datetime.fromtimestamp(iat).isoformat() in msg
-        assert datetime.fromtimestamp(exp).isoformat() in msg
+        assert datetime.fromtimestamp(iat).strftime("%Y-%m-%d %H:%M:%S") in msg
+        assert datetime.fromtimestamp(exp).strftime("%Y-%m-%d %H:%M:%S") in msg
 
 
 def test_check_suspicious_iat_includes_timestamp():
@@ -29,4 +29,4 @@ def test_check_suspicious_iat_includes_timestamp():
     with mock.patch('jwtek.core.ui.warn') as warn, mock.patch('time.time', return_value=0):
         sa.check_suspicious_iat(payload)
         warn.assert_called()
-        assert datetime.fromtimestamp(iat).isoformat() in warn.call_args[0][0]
+        assert datetime.fromtimestamp(iat).strftime("%Y-%m-%d %H:%M:%S") in warn.call_args[0][0]


### PR DESCRIPTION
## Summary
- format static analysis timestamps without ISO "T" delimiter
- update parser to display timestamps in `YYYY-MM-DD HH:MM:SS` format
- adjust tests to expect the new timestamp style

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b6dae7356083278d1f72dd45e09ab6