### PR TITLE
feat: allow saving scraped JWT to custom path

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,13 +84,14 @@ jwtek analyze --token <JWT> --jwks <JWKS_URL>
 jwtek analyze --token <JWT> --secret mysecret
 jwtek analyze --file ./tokens.txt --analyze-all
 jwtek analyze --login https://example.com/login --dashboard https://example.com/app
+jwtek analyze --login https://example.com/login --dashboard https://example.com/app --sP myjwt.txt
 ```
 
 Using `--login` and `--dashboard` launches a Chromium browser via Playwright. Log
 in manually on the provided login page, press Enter in the terminal, and JWTEK
 will navigate to the dashboard, capturing any JWTs from network traffic, cookies
-and web storage. Tokens are saved to `jwt.txt` for further analysis.
-
+and web storage. Tokens are saved to `jwt.txt` by default or to a custom path
+specified with `--sP` for further analysis.
 
 ### 💣 Exploitation Guidance
 

--- a/jwtek/__main__.py
+++ b/jwtek/__main__.py
@@ -210,6 +210,7 @@ def main(argv=None):
     analyze_parser.add_argument('--json-out', help='Write analysis results to JSON file')
     analyze_parser.add_argument('--login', help='Login URL for interactive scraping')
     analyze_parser.add_argument('--dashboard', help='Dashboard URL for scraping after login')
+    analyze_parser.add_argument('--sP', help='Path to save scraped JWTs')
 
     # === exploit ===
     exploit_parser = subparsers.add_parser('exploit', help='Show exploitation guidance')
@@ -256,9 +257,10 @@ def main(argv=None):
         token = getattr(args, 'token', None)
 
         if args.login and args.dashboard:
-            scraper.login_and_scrape(args.login, args.dashboard)
+            out_path = args.sP or "jwt.txt"
+            scraper.login_and_scrape(args.login, args.dashboard, out_path=out_path)
             if not token and not getattr(args, 'file', None):
-                token = extractor.extract_from_file("jwt.txt")
+                token = extractor.extract_from_file(out_path)
                 if token:
                     print(f"[+] Extracted JWT:\n{token}\n")
                 else:

--- a/tests/test_cli_save_path.py
+++ b/tests/test_cli_save_path.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import sys
+
+from jwtek.__main__ import main
+from jwtek.core import scraper, extractor, parser, static_analysis, ui
+
+
+def test_save_path_option(monkeypatch, tmp_path):
+    save_file = tmp_path / "custom.txt"
+    called = {}
+
+    def fake_login_and_scrape(login, dashboard, out_path):
+        called["out_path"] = out_path
+        Path(out_path).write_text("a.b.c")
+
+    def fake_extract_from_file(path):
+        called["extract_path"] = path
+        return "a.b.c"
+
+    monkeypatch.setattr(scraper, "login_and_scrape", fake_login_and_scrape)
+    monkeypatch.setattr(extractor, "extract_from_file", fake_extract_from_file)
+    monkeypatch.setattr(parser, "decode_jwt", lambda token: ({}, {}, ""))
+    monkeypatch.setattr(parser, "pretty_print_jwt", lambda h, p, s: None)
+    monkeypatch.setattr(static_analysis, "run_all_checks", lambda h, p: None)
+    monkeypatch.setattr(ui, "section", lambda x: None)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "jwtek",
+            "analyze",
+            "--login",
+            "http://login",
+            "--dashboard",
+            "http://dashboard",
+            "--sP",
+            str(save_file),
+        ],
+    )
+
+    main()
+
+    assert called["out_path"] == str(save_file)
+    assert called["extract_path"] == str(save_file)


### PR DESCRIPTION
## Summary
- allow users to set save location for scraped JWTs via `--sP`
- document custom save path option and add regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b988612c20832785283b48369017dc