### PR TITLE
Switch JWTEK CLI flags to single hyphen

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ different ways:
 
 ### 1. `analyze`
 - Decode a token and run static checks
-- Optional `--pubkey` to verify RS256 signatures
-- Optional `--secret` to verify HS256/384/512 signatures
-- `--audit` highlights suspicious privilege claims
-- Tokens can also be extracted from files with `--file` or analysed in batch
-  using `--analyze-all`
+- Optional `-pubkey` to verify RS256 signatures
+- Optional `-secret` to verify HS256/384/512 signatures
+- `-audit` highlights suspicious privilege claims
+- Tokens can also be extracted from files with `-file` or analysed in batch
+  using `-analyze-all`
 
 ### 2. `exploit`
 - Get exploitation tips, generate PoC tokens, or attempt auth bypass testing
@@ -60,7 +60,7 @@ different ways:
 - Forge custom tokens or convert existing ones using `none`, `HS256`, or `RS256`
 - Guided exploitation advice with PoCs and bypass testing
 - Extendable and modular structure
-- Colored console output for readability (disable with `--no-color` or `JWTEK_NO_COLOR=1`)
+- Colored console output for readability (disable with `-no-color` or `JWTEK_NO_COLOR=1`)
 
 ---
 
@@ -70,54 +70,54 @@ different ways:
 jwtek <command> [options]
 ```
 The `jwtek` command becomes available after installation.
-Use `--no-color` or set `JWTEK_NO_COLOR=1` to disable ANSI colours.
+Use `-no-color` or set `JWTEK_NO_COLOR=1` to disable ANSI colours.
 
 ### 🔍 Analyze a JWT
 
-Use `--analyze-all` to extract and analyze every JWT from a file. Differences
+Use `-analyze-all` to extract and analyze every JWT from a file. Differences
 between sequential tokens are displayed automatically at the end of the output.
 
 ```bash
-jwtek analyze --token <JWT>
-jwtek analyze --token <JWT> --pubkey ./public.pem --audit
-jwtek analyze --token <JWT> --jwks <JWKS_URL>
-jwtek analyze --token <JWT> --secret mysecret
-jwtek analyze --file ./tokens.txt --analyze-all
-jwtek analyze --login https://example.com/login --dashboard https://example.com/app
-jwtek analyze --login https://example.com/login --dashboard https://example.com/app --sP myjwt.txt
+jwtek analyze -token <JWT>
+jwtek analyze -token <JWT> -pubkey ./public.pem -audit
+jwtek analyze -token <JWT> -jwks <JWKS_URL>
+jwtek analyze -token <JWT> -secret mysecret
+jwtek analyze -file ./tokens.txt -analyze-all
+jwtek analyze -login https://example.com/login -dashboard https://example.com/app
+jwtek analyze -login https://example.com/login -dashboard https://example.com/app -sP myjwt.txt
 ```
 
-Using `--login` and `--dashboard` launches a Chromium browser via Playwright. Log
+Using `-login` and `-dashboard` launches a Chromium browser via Playwright. Log
 in manually on the provided login page, press Enter in the terminal, and JWTEK
 will navigate to the dashboard, capturing any JWTs from network traffic, cookies
 and web storage. Tokens are saved to `jwt.txt` by default or to a custom path
-specified with `--sP` for further analysis.
+specified with `-sP` for further analysis.
 
 ### 💣 Exploitation Guidance
 
 ```bash
-jwtek exploit --vuln alg-none
-jwtek exploit --vuln hs256-key-found --secret secret123
-jwtek exploit --vuln alg-swap-rs256
-jwtek exploit --vuln jku-header
-jwtek exploit --vuln suspicious-kid
+jwtek exploit -vuln alg-none
+jwtek exploit -vuln hs256-key-found -secret secret123
+jwtek exploit -vuln alg-swap-rs256
+jwtek exploit -vuln jku-header
+jwtek exploit -vuln suspicious-kid
 ```
 
 ```bash
 # List all exploit IDs
-jwtek exploit --list
+jwtek exploit -list
 ```
 
 ### ✨ Forge a JWT
 
-The `forge` command can create a token from a JSON payload or convert an existing JWT using `--token`.
+The `forge` command can create a token from a JSON payload or convert an existing JWT using `-token`.
 
 ```bash
 # Forge from a payload
-jwtek forge --alg HS256 --payload '{"sub":"1234567890","name":"John Doe","admin":true}' --secret secret
+jwtek forge -alg HS256 -payload '{"sub":"1234567890","name":"John Doe","admin":true}' -secret secret
 
 # Convert an RS256 token to alg none
-jwtek forge --alg none --token <JWT>
+jwtek forge -alg none -token <JWT>
 ```
 
 ### 🔄 Update JWTEK

--- a/jwtek/__main__.py
+++ b/jwtek/__main__.py
@@ -194,55 +194,55 @@ def main(argv=None):
         prog='jwtek',
         description="🛡️ JWTEK: JWT Security Analysis & Exploitation Tool"
     )
-    parser_cli.add_argument('--no-color', action='store_true', help='Disable colored output')
+    parser_cli.add_argument('-no-color', action='store_true', help='Disable colored output')
 
     subparsers = parser_cli.add_subparsers(dest='command', help='Available commands')
 
     # === analyze ===
     analyze_parser = subparsers.add_parser('analyze', help='Static (or optional RS256) analysis of a JWT')
-    analyze_parser.add_argument('--token', required=False, help='JWT string to analyze')
-    analyze_parser.add_argument('--pubkey', help='Optional path to public key (PEM) for signature verification')
-    analyze_parser.add_argument('--jwks', help='URL to JWKS for signature verification')
-    analyze_parser.add_argument('--secret', help='Shared secret for HS256/384/512 verification')
-    analyze_parser.add_argument('--audit', action='store_true', help='Audit JWT claims for privilege abuse')
-    analyze_parser.add_argument('--file', help='Path to file to extract JWT from')
-    analyze_parser.add_argument('--analyze-all', action='store_true', help='Extract and analyze all JWTs from file')
-    analyze_parser.add_argument('--json-out', help='Write analysis results to JSON file')
-    analyze_parser.add_argument('--login', help='Login URL for interactive scraping')
-    analyze_parser.add_argument('--dashboard', help='Dashboard URL for scraping after login')
-    analyze_parser.add_argument('--sP', help='Path to save scraped JWTs')
+    analyze_parser.add_argument('-token', required=False, help='JWT string to analyze')
+    analyze_parser.add_argument('-pubkey', help='Optional path to public key (PEM) for signature verification')
+    analyze_parser.add_argument('-jwks', help='URL to JWKS for signature verification')
+    analyze_parser.add_argument('-secret', help='Shared secret for HS256/384/512 verification')
+    analyze_parser.add_argument('-audit', action='store_true', help='Audit JWT claims for privilege abuse')
+    analyze_parser.add_argument('-file', help='Path to file to extract JWT from')
+    analyze_parser.add_argument('-analyze-all', action='store_true', help='Extract and analyze all JWTs from file')
+    analyze_parser.add_argument('-json-out', help='Write analysis results to JSON file')
+    analyze_parser.add_argument('-login', help='Login URL for interactive scraping')
+    analyze_parser.add_argument('-dashboard', help='Dashboard URL for scraping after login')
+    analyze_parser.add_argument('-sP', help='Path to save scraped JWTs')
 
     # === exploit ===
     exploit_parser = subparsers.add_parser('exploit', help='Show exploitation guidance')
-    exploit_parser.add_argument('--vuln', help='Vulnerability ID (e.g., alg-none)')
-    exploit_parser.add_argument('--secret', help='Optional secret key (for PoC or bypass)')
-    exploit_parser.add_argument('--url', help='Target URL for bypass testing')
-    exploit_parser.add_argument('--jwks', help='JWKS URL to fetch key for certain exploits')
-    exploit_parser.add_argument('--poc', action='store_true', help='Generate PoC token')
-    exploit_parser.add_argument('--bypass', action='store_true', help='Attempt authentication bypass using token')
-    exploit_parser.add_argument('--list', action='store_true', help='List available vulnerability IDs')
+    exploit_parser.add_argument('-vuln', help='Vulnerability ID (e.g., alg-none)')
+    exploit_parser.add_argument('-secret', help='Optional secret key (for PoC or bypass)')
+    exploit_parser.add_argument('-url', help='Target URL for bypass testing')
+    exploit_parser.add_argument('-jwks', help='JWKS URL to fetch key for certain exploits')
+    exploit_parser.add_argument('-poc', action='store_true', help='Generate PoC token')
+    exploit_parser.add_argument('-bypass', action='store_true', help='Attempt authentication bypass using token')
+    exploit_parser.add_argument('-list', action='store_true', help='List available vulnerability IDs')
 
     # === forge ===
     forge_parser = subparsers.add_parser('forge', help="Forge a custom JWT token")
-    forge_parser.add_argument('--alg', required=True, help="Algorithm to use (HS256, RS256, ES256, PS256, none)")
+    forge_parser.add_argument('-alg', required=True, help="Algorithm to use (HS256, RS256, ES256, PS256, none)")
     forge_parser.add_argument(
-        '--payload',
+        '-payload',
         required=False,
         help=(
             "JSON payload string, e.g. '{\"sub\":\"1234567890\","
-            "\"name\":\"John Doe\",\"admin\":true}' (optional if --token is provided)"
+            "\"name\":\"John Doe\",\"admin\":true}' (optional if -token is provided)"
         ),
     )
-    forge_parser.add_argument('--token', help='Existing JWT to convert/re-sign')
-    forge_parser.add_argument('--secret', help="Secret key for HS256 (optional)")
-    forge_parser.add_argument('--pubkey', help='Path to RSA public key (for RS256)')
-    forge_parser.add_argument('--privkey', help='Path to RSA private key (for RS256/ES256/PS256)')
-    forge_parser.add_argument('--kid', help='Optional kid header value')
+    forge_parser.add_argument('-token', help='Existing JWT to convert/re-sign')
+    forge_parser.add_argument('-secret', help="Secret key for HS256 (optional)")
+    forge_parser.add_argument('-pubkey', help='Path to RSA public key (for RS256)')
+    forge_parser.add_argument('-privkey', help='Path to RSA private key (for RS256/ES256/PS256)')
+    forge_parser.add_argument('-kid', help='Optional kid header value')
 
     # === brute ===
     brute_parser = subparsers.add_parser('brute', help='Brute force HS* secret key')
-    brute_parser.add_argument('--token', required=True, help='JWT token to crack')
-    brute_parser.add_argument('--wordlist', required=True, help='Path to wordlist of secrets')
+    brute_parser.add_argument('-token', required=True, help='JWT token to crack')
+    brute_parser.add_argument('-wordlist', required=True, help='Path to wordlist of secrets')
 
     # === update ===
     subparsers.add_parser('update', help='Update JWTEK to the latest version')
@@ -288,7 +288,7 @@ def main(argv=None):
                 print(f"[+] Extracted JWT:\n{token}\n")
 
         if not token:
-            print("[!] Please provide a JWT token using --token or extract it using --file.")
+            print("[!] Please provide a JWT token using -token or extract it using -file.")
             return
 
         # 🧠 Proceed to analyze the token
@@ -331,17 +331,17 @@ def main(argv=None):
                 exploits.generate_poc_token(args.vuln, secret=args.secret, jwks_url=args.jwks)
             elif args.bypass:
                 if not args.url:
-                    print("[!] --url is required for bypass testing.")
+                    print("[!] -url is required for bypass testing.")
                 else:
                     exploits.attempt_bypass(args.vuln, args.secret or "", args.url, jwks_url=args.jwks)
             else:
                 exploits.explain_exploit(args.vuln, secret=args.secret)
         else:
-            print("[!] Use --vuln to specify a vulnerability ID or --list to see options.")
+            print("[!] Use -vuln to specify a vulnerability ID or -list to see options.")
 
     elif args.command == 'forge':
         if (args.payload and args.token) or (not args.payload and not args.token):
-            print("[!] Provide either --payload or --token.")
+            print("[!] Provide either -payload or -token.")
             return
         forge.forge_jwt(
             alg=args.alg,
@@ -365,7 +365,7 @@ if __name__ == '__main__':
     import sys
     if len(sys.argv) == 1:
         # Show full CLI help if no args passed
-        main(['--help'])
+        main(['-h'])
     else:
         main()
 

--- a/jwtek/core/exploits.py
+++ b/jwtek/core/exploits.py
@@ -119,7 +119,7 @@ def explain_exploit(vuln_id, **kwargs):
     elif vuln_id == "hs256-key-found":
         secret = kwargs.get("secret")
         if not secret:
-            ui.error("[!] Missing --secret argument.")
+            ui.error("[!] Missing -secret argument.")
         else:
             explain_hs256_key_found(secret)
     elif vuln_id == "alg-swap-rs256":

--- a/jwtek/core/forge.py
+++ b/jwtek/core/forge.py
@@ -36,7 +36,7 @@ def forge_jwt(alg, payload_str=None, token=None, secret=None, privkey_path=None,
 
     elif alg == "HS256":
         if not secret:
-            ui.error("HS256 requires --secret to sign the token.")
+            ui.error("HS256 requires -secret to sign the token.")
             return
         token = jwt.encode(payload, secret, algorithm="HS256", headers=header)
         ui.success("\n[+] Forged JWT (HS256):")
@@ -45,7 +45,7 @@ def forge_jwt(alg, payload_str=None, token=None, secret=None, privkey_path=None,
 
     elif alg in {"RS256", "ES256", "PS256"}:
         if not privkey_path:
-            ui.error("{} requires --privkey path to sign the token.".format(alg))
+            ui.error("{} requires -privkey path to sign the token.".format(alg))
             return
         try:
             with open(privkey_path, "r") as f:

--- a/jwtek/core/static_analysis.py
+++ b/jwtek/core/static_analysis.py
@@ -101,4 +101,4 @@ def check_rs256_alg_downgrade(header):
     if alg.upper() == "RS256":
         ui.warn("Warning: Token uses RS256 (asymmetric). Check if the backend verifies key type correctly.")
         ui.warn("    Possible downgrade to HS256 and signature using public key as HMAC secret.")
-        ui.warn("    → Try exploit: jwtek exploit --vuln alg-swap-rs256\n")
+        ui.warn("    → Try exploit: jwtek exploit -vuln alg-swap-rs256\n")

--- a/jwtek/core/ui.py
+++ b/jwtek/core/ui.py
@@ -5,7 +5,7 @@ from termcolor import cprint
 
 
 # Determine if colors should be disabled either via environment variable or
-# runtime flag.  The ``JWTEK_NO_COLOR`` env var mirrors the ``--no-color`` CLI
+# runtime flag.  The ``JWTEK_NO_COLOR`` env var mirrors the ``-no-color`` CLI
 # option added in ``__main__``.  Tests also modify this flag directly.
 NO_COLOR = os.environ.get("JWTEK_NO_COLOR") == "1"
 

--- a/tests/test_cli_save_path.py
+++ b/tests/test_cli_save_path.py
@@ -31,11 +31,11 @@ def test_save_path_option(monkeypatch, tmp_path):
         [
             "jwtek",
             "analyze",
-            "--login",
+            "-login",
             "http://login",
-            "--dashboard",
+            "-dashboard",
             "http://dashboard",
-            "--sP",
+            "-sP",
             str(save_file),
         ],
     )


### PR DESCRIPTION
## Summary
- Replace all double-hyphen flags with single-hyphen equivalents across JWTEK CLI commands
- Update internal error and help messages to reference new single-hyphen options
- Revise documentation and tests to demonstrate and exercise updated flag syntax

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68ba787595908327ae122a1b46cab16e