### PR TITLE
Fix missing pyee dependency for Playwright

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "requests",
     "termcolor",
     "playwright",
+    "pyee",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyjwt
 termcolor
 requests
 playwright
+pyee


### PR DESCRIPTION
## Summary
- add pyee to required dependencies to prevent missing module errors when using Playwright

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68c3ef1a9c848327ac7e417415bbab1a