### PR TITLE
Add tab completion support for private key prompt

### DIFF
--- a/jwtek/core/forge.py
+++ b/jwtek/core/forge.py
@@ -242,7 +242,7 @@ def interactive_edit(header, payload, signature):
             payload_dict=working_payload,
         )
     elif algorithm in {"RS256", "ES256", "PS256"}:
-        privkey_path = input(f"Path to private key for {algorithm} signing: ").strip()
+        privkey_path = ui.prompt_path(f"Path to private key for {algorithm} signing: ").strip()
         if not privkey_path:
             ui.error(f"Private key path is required for {algorithm} tokens.")
             return

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,26 @@
+from jwtek.core import ui
+
+
+def test_path_completion_lists_directory_contents(tmp_path):
+    (tmp_path / "alpha").mkdir()
+    (tmp_path / "bravo.txt").write_text("data")
+
+    matches = ui._path_completion_options("", base_dir=str(tmp_path))
+
+    assert "alpha/" in matches
+    assert "bravo.txt" in matches
+
+
+def test_path_completion_with_prefix_and_nested_dirs(tmp_path):
+    nested = tmp_path / "alpha" / "nested"
+    nested.mkdir(parents=True)
+    (tmp_path / "alphabet.txt").write_text("data")
+
+    matches = ui._path_completion_options("al", base_dir=str(tmp_path))
+    assert matches == ["alpha/", "alphabet.txt"]
+
+    nested_matches = ui._path_completion_options("alpha/", base_dir=str(tmp_path))
+    assert nested_matches == ["alpha/nested/"]
+
+    deeper_matches = ui._path_completion_options("alpha/n", base_dir=str(tmp_path))
+    assert deeper_matches == ["alpha/nested/"]


### PR DESCRIPTION
## Summary
- add a readline-backed helper to offer filesystem path tab completion
- use the interactive path prompt when requesting a private key for RS/ES/PS signing
- add tests to cover the new path completion behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca8c1223888327be7f6a2534e12d9c