### PR TITLE
Add JWKS conversion command and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ different ways:
 - RS256 → HS256 downgrade detection
 - Extracts tokens from files and supports batch analysis
 - Forge custom tokens or convert existing ones using `none`, `HS256`, or `RS256`
+- Convert JWKS documents into PEM files for interoperability
 - Guided exploitation advice with PoCs and bypass testing
 - Extendable and modular structure
 - Colored console output for readability (disable with `-no-color` or `JWTEK_NO_COLOR=1`)
@@ -118,6 +119,18 @@ jwtek forge --alg HS256 --payload '{"sub":"1234567890","name":"John Doe","admin"
 
 # Convert an RS256 token to alg none
 jwtek forge --alg none --token <JWT>
+```
+
+### 🔁 Convert JWKS to PEM
+
+Extract PEM encoded RSA public keys from a JWKS document saved on disk. When
+the JWKS contains multiple keys a directory output is required so each key is
+saved to a separate file named after its `kid` (or index if the `kid` is
+missing).
+
+```bash
+jwtek convert --input ./jwks.json --output ./public.pem
+jwtek convert --input ./jwks.json --output ./pem-keys/
 ```
 
 ### 🔄 Update JWTEK

--- a/jwtek/core/converter.py
+++ b/jwtek/core/converter.py
@@ -1,0 +1,243 @@
+"""Utilities for converting JSON Web Keys (JWK/JWKS) into PEM files.
+
+This module focuses on the common need to take a JWKS document – often
+returned by an identity provider – and extract the contained RSA public keys as
+PEM encoded files so they can be used with tooling that expects the PEM format.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from base64 import b64encode, urlsafe_b64decode
+from pathlib import Path
+from typing import List
+
+
+class JWKSConversionError(Exception):
+    """Raised when a JWKS document cannot be converted into PEM keys."""
+
+
+def _ensure_dir(path: Path) -> None:
+    """Create *path* as a directory if it does not already exist."""
+
+    if path.exists() and not path.is_dir():
+        raise JWKSConversionError(f"{path} exists and is not a directory")
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _b64_to_int(data: str) -> int:
+    """Decode a base64url encoded integer."""
+
+    padding = "=" * (-len(data) % 4)
+    decoded = urlsafe_b64decode(data + padding)
+    return int.from_bytes(decoded, "big")
+
+
+def _encode_length(length: int) -> bytes:
+    if length < 0x80:
+        return bytes([length])
+
+    encoded: list[int] = []
+    value = length
+    while value > 0:
+        encoded.append(value & 0xFF)
+        value >>= 8
+
+    return bytes([0x80 | len(encoded)]) + bytes(reversed(encoded))
+
+
+def _encode_integer(value: int) -> bytes:
+    if value < 0:
+        raise JWKSConversionError("Negative integers are not supported")
+
+    if value == 0:
+        raw = b"\x00"
+    else:
+        raw = value.to_bytes((value.bit_length() + 7) // 8, "big")
+        if raw[0] & 0x80:
+            raw = b"\x00" + raw
+
+    return b"\x02" + _encode_length(len(raw)) + raw
+
+
+def _encode_sequence(parts: List[bytes]) -> bytes:
+    body = b"".join(parts)
+    return b"\x30" + _encode_length(len(body)) + body
+
+
+def _encode_base128(value: int) -> bytes:
+    if value == 0:
+        return b"\x00"
+
+    pieces: list[int] = []
+    while value > 0:
+        pieces.append(value & 0x7F)
+        value >>= 7
+
+    encoded = bytearray()
+    for piece in reversed(pieces):
+        encoded.append(piece | 0x80)
+    encoded[-1] &= 0x7F
+    return bytes(encoded)
+
+
+def _encode_object_identifier(oid: tuple[int, ...]) -> bytes:
+    if len(oid) < 2:
+        raise JWKSConversionError("OID must contain at least two components")
+
+    first = 40 * oid[0] + oid[1]
+    body = bytes([first]) + b"".join(_encode_base128(x) for x in oid[2:])
+    return b"\x06" + _encode_length(len(body)) + body
+
+
+def _encode_null() -> bytes:
+    return b"\x05\x00"
+
+
+def _encode_bit_string(data: bytes) -> bytes:
+    return b"\x03" + _encode_length(len(data) + 1) + b"\x00" + data
+
+
+def _pem_wrap(der_bytes: bytes) -> bytes:
+    base64_body = b64encode(der_bytes).decode("ascii")
+    wrapped = "\n".join(textwrap.wrap(base64_body, 64))
+    return (
+        "-----BEGIN PUBLIC KEY-----\n"
+        + wrapped
+        + "\n-----END PUBLIC KEY-----\n"
+    ).encode("ascii")
+
+
+def _rsa_pem_from_jwk(jwk: dict) -> bytes:
+    """Return PEM encoded RSA public key from *jwk*."""
+
+    try:
+        n = _b64_to_int(jwk["n"])
+        e = _b64_to_int(jwk["e"])
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        missing = exc.args[0]
+        raise JWKSConversionError(f"RSA JWK missing required parameter: {missing}") from exc
+
+    rsa_sequence = _encode_sequence([
+        _encode_integer(n),
+        _encode_integer(e),
+    ])
+
+    algorithm_identifier = _encode_sequence([
+        _encode_object_identifier((1, 2, 840, 113549, 1, 1, 1)),
+        _encode_null(),
+    ])
+
+    spki = _encode_sequence([
+        algorithm_identifier,
+        _encode_bit_string(rsa_sequence),
+    ])
+
+    return _pem_wrap(spki)
+
+
+def _jwk_to_pem(jwk: dict) -> bytes:
+    """Convert a single JWK dictionary to PEM encoded bytes."""
+
+    kty = jwk.get("kty")
+    if kty == "RSA":
+        return _rsa_pem_from_jwk(jwk)
+    raise JWKSConversionError(f"Unsupported key type: {kty}")
+
+
+def _sanitize_filename(name: str) -> str:
+    """Return a filesystem friendly version of *name*."""
+
+    safe = [c if c.isalnum() or c in ("-", "_") else "-" for c in name]
+    sanitized = "".join(safe).strip("-")
+    return sanitized or "key"
+
+
+def _determine_output_path(
+    base_output: Path | None,
+    jwks_path: Path,
+    key_identifier: str,
+    multiple_keys: bool,
+) -> Path:
+    """Return output path for a key based on provided options."""
+
+    filename = f"{_sanitize_filename(key_identifier)}.pem"
+
+    if base_output is None:
+        return jwks_path.with_name(filename)
+
+    if base_output.exists():
+        if base_output.is_dir():
+            return base_output / filename
+        if multiple_keys:
+            raise JWKSConversionError("Cannot write multiple keys to a single PEM file")
+        return base_output
+
+    # Path does not exist yet
+    if base_output.suffix:  # looks like a file
+        if multiple_keys:
+            raise JWKSConversionError("Cannot write multiple keys to a single PEM file")
+        parent = base_output.parent
+        if parent and not parent.exists():
+            parent.mkdir(parents=True, exist_ok=True)
+        return base_output
+
+    # treat as directory
+    _ensure_dir(base_output)
+    return base_output / filename
+
+
+def convert_jwks_to_pem(
+    jwks_path: str | Path,
+    output_path: str | Path | None = None,
+) -> List[Path]:
+    """Convert keys from *jwks_path* into PEM files.
+
+    Parameters
+    ----------
+    jwks_path:
+        Path to a JWKS (JSON Web Key Set) document on disk.
+    output_path:
+        Optional directory or file path to place the converted PEM files.  If a
+        directory is supplied, each key is saved as ``<kid>.pem`` inside that
+        directory.  If a file path is provided the JWKS must contain exactly one
+        key, which is written to the specified file.
+
+    Returns
+    -------
+    list[pathlib.Path]
+        The paths of the PEM files that were written.
+    """
+
+    jwks_path = Path(jwks_path)
+    if not jwks_path.is_file():
+        raise JWKSConversionError(f"JWKS file not found: {jwks_path}")
+
+    with jwks_path.open("r", encoding="utf-8") as fh:
+        try:
+            jwks = json.load(fh)
+        except json.JSONDecodeError as exc:
+            raise JWKSConversionError("Invalid JWKS JSON") from exc
+
+    keys = list(jwks.get("keys") or [])
+    if not keys:
+        raise JWKSConversionError("JWKS does not contain any keys")
+
+    base_output = Path(output_path) if output_path is not None else None
+    if base_output is not None and not base_output.exists() and not base_output.suffix:
+        _ensure_dir(base_output)
+
+    written_paths: List[Path] = []
+    multiple = len(keys) > 1
+
+    for index, jwk in enumerate(keys):
+        kid = jwk.get("kid") or f"key-{index}"
+        pem_bytes = _jwk_to_pem(jwk)
+        target_path = _determine_output_path(base_output, jwks_path, kid, multiple)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_bytes(pem_bytes)
+        written_paths.append(target_path)
+
+    return written_paths
+

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,144 @@
+import json
+from base64 import b64decode, urlsafe_b64encode
+
+import pytest
+
+from jwtek.__main__ import main
+from jwtek.core import converter
+
+
+MODULUS_ONE = int(
+    "0xc7f1d2e3a4b5968778695a4b3c2d1e0f112233445566778899aabbccddeeff00"
+    "fedcba98765432100123456789abcdef112233445566778899aabbccddeeff11",
+    16,
+)
+MODULUS_TWO = int(
+    "0xd5e6f708192a3b4c5d6e7f8091a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4"
+    "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff",
+    16,
+)
+EXPONENT = 65537
+
+
+def _to_b64(number: int) -> str:
+    length = (number.bit_length() + 7) // 8
+    return (
+        urlsafe_b64encode(number.to_bytes(length, "big"))
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+
+
+def _read_length(data: bytes, offset: int) -> tuple[int, int]:
+    first = data[offset]
+    offset += 1
+    if first < 0x80:
+        return first, offset
+
+    num_octets = first & 0x7F
+    length = int.from_bytes(data[offset:offset + num_octets], "big")
+    offset += num_octets
+    return length, offset
+
+
+def _read_tlv(expected_tag: int, data: bytes, offset: int) -> tuple[bytes, int]:
+    tag = data[offset]
+    if tag != expected_tag:  # pragma: no cover - defensive guard
+        raise AssertionError(f"Unexpected tag: {tag:#x}")
+
+    length, offset = _read_length(data, offset + 1)
+    value = data[offset:offset + length]
+    offset += length
+    return value, offset
+
+
+def _extract_public_numbers(pem_bytes: bytes) -> tuple[int, int]:
+    lines = [
+        line.strip()
+        for line in pem_bytes.decode("ascii").splitlines()
+        if line and not line.startswith("-----")
+    ]
+    der = b64decode("".join(lines))
+
+    spki, consumed = _read_tlv(0x30, der, 0)
+    assert consumed == len(der)
+
+    alg, offset = _read_tlv(0x30, spki, 0)
+    # we do not inspect the algorithm identifier beyond ensuring it parses
+    assert offset <= len(spki)
+    bit_string, offset = _read_tlv(0x03, spki, offset)
+    assert offset == len(spki)
+    assert bit_string[0] == 0
+
+    rsa_sequence, consumed = _read_tlv(0x30, bit_string[1:], 0)
+    assert consumed == len(bit_string) - 1
+
+    modulus_bytes, seq_offset = _read_tlv(0x02, rsa_sequence, 0)
+    exponent_bytes, seq_offset = _read_tlv(0x02, rsa_sequence, seq_offset)
+    assert seq_offset == len(rsa_sequence)
+
+    modulus = int.from_bytes(modulus_bytes, "big")
+    exponent = int.from_bytes(exponent_bytes, "big")
+    return modulus, exponent
+
+
+def _jwks_for_key(kid: str, modulus: int) -> dict:
+    return {
+        "kty": "RSA",
+        "kid": kid,
+        "n": _to_b64(modulus),
+        "e": _to_b64(EXPONENT),
+    }
+
+
+def test_convert_single_jwk_to_specific_file(tmp_path):
+    jwk = _jwks_for_key("kid1", MODULUS_ONE)
+    jwks_file = tmp_path / "jwks.json"
+    jwks_file.write_text(json.dumps({"keys": [jwk]}), encoding="utf-8")
+
+    output_file = tmp_path / "public.pem"
+    written = converter.convert_jwks_to_pem(jwks_file, output_file)
+    assert written == [output_file]
+
+    modulus, exponent = _extract_public_numbers(output_file.read_bytes())
+    assert modulus == MODULUS_ONE
+    assert exponent == EXPONENT
+
+    cli_output = tmp_path / "cli.pem"
+    main(['convert', '-i', str(jwks_file), '-o', str(cli_output)])
+    assert cli_output.exists()
+    cli_modulus, cli_exponent = _extract_public_numbers(cli_output.read_bytes())
+    assert cli_modulus == MODULUS_ONE
+    assert cli_exponent == EXPONENT
+
+
+def test_convert_multiple_keys_to_directory(tmp_path):
+    jwk_one = _jwks_for_key("kid one", MODULUS_ONE)
+    jwk_two = _jwks_for_key("kid/two", MODULUS_TWO)
+    jwks_file = tmp_path / "multi.json"
+    jwks_file.write_text(json.dumps({"keys": [jwk_one, jwk_two]}), encoding="utf-8")
+
+    output_dir = tmp_path / "output"
+    written_paths = converter.convert_jwks_to_pem(jwks_file, output_dir)
+    assert len(written_paths) == 2
+
+    expected_one = output_dir / "kid-one.pem"
+    expected_two = output_dir / "kid-two.pem"
+    assert set(written_paths) == {expected_one, expected_two}
+
+    mod_one, exp_one = _extract_public_numbers(expected_one.read_bytes())
+    mod_two, exp_two = _extract_public_numbers(expected_two.read_bytes())
+    assert mod_one == MODULUS_ONE
+    assert exp_one == EXPONENT
+    assert mod_two == MODULUS_TWO
+    assert exp_two == EXPONENT
+
+
+def test_multiple_keys_to_single_file_raises(tmp_path):
+    jwk_one = _jwks_for_key("a", MODULUS_ONE)
+    jwk_two = _jwks_for_key("b", MODULUS_TWO)
+    jwks_file = tmp_path / "double.json"
+    jwks_file.write_text(json.dumps({"keys": [jwk_one, jwk_two]}), encoding="utf-8")
+
+    with pytest.raises(converter.JWKSConversionError):
+        converter.convert_jwks_to_pem(jwks_file, tmp_path / "single.pem")


### PR DESCRIPTION
## Summary
- add a converter module that turns RSA keys from a JWKS document into PEM files
- expose the conversion feature via a new `jwtek convert` CLI subcommand and document its usage
- cover the converter logic with dedicated tests for single and multi-key JWKS inputs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68caa3954af88327b9f324684f80f10f