### PR TITLE
Add interactive path picker using prompt_toolkit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "termcolor",
     "playwright",
     "pyee",
+    "prompt_toolkit",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ termcolor
 requests
 playwright
 pyee
+prompt_toolkit


### PR DESCRIPTION
## Summary
- prefer prompt_toolkit's rich path completer when prompting for filesystem paths
- keep the existing readline fallback for environments without prompt_toolkit
- add prompt_toolkit to the project dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68caa8e2f98083278e261c712fa71226